### PR TITLE
Knowledgebase refactor

### DIFF
--- a/openagent/knowledgebase/document_loaders/airtable/base.py
+++ b/openagent/knowledgebase/document_loaders/airtable/base.py
@@ -30,7 +30,7 @@ class AirtableReader(BaseReader):
 
         metadata = {"base_id": base_id, 
                     "table_id": table_id,
-                     "loader_key":"airtable"
+                     "loader_id":"airtable"
                 }
 
         table = Table(self.api_key, base_id, table_id)

--- a/openagent/knowledgebase/document_loaders/airtable/base.py
+++ b/openagent/knowledgebase/document_loaders/airtable/base.py
@@ -29,7 +29,8 @@ class AirtableReader(BaseReader):
         from pyairtable import Table 
 
         metadata = {"base_id": base_id, 
-                    "table_id": table_id
+                    "table_id": table_id,
+                     "loader_key":"airtable"
                 }
 
         table = Table(self.api_key, base_id, table_id)

--- a/openagent/knowledgebase/document_loaders/apify/dataset/base.py
+++ b/openagent/knowledgebase/document_loaders/apify/dataset/base.py
@@ -32,10 +32,11 @@ class ApifyDataset(BaseReader):
         items_list = self.apify_client.dataset(dataset_id).list_items(clean=True)
 
         document_list = []
+        metadata = {"loader_key":"apify_dataset"}
         for item in items_list.items:
             DocumentNode = dataset_mapping_function(item)
             if not isinstance(DocumentNode, DocumentNode):
                 raise ValueError("Dataset_mapping_function must return a DocumentNode")
-            document_list.append(DocumentNode)
+            document_list.append(DocumentNode(extra_info=metadata))
 
         return document_list

--- a/openagent/knowledgebase/document_loaders/apify/dataset/base.py
+++ b/openagent/knowledgebase/document_loaders/apify/dataset/base.py
@@ -32,7 +32,7 @@ class ApifyDataset(BaseReader):
         items_list = self.apify_client.dataset(dataset_id).list_items(clean=True)
 
         document_list = []
-        metadata = {"loader_key":"apify_dataset"}
+        metadata = {"loader_id":"apify_dataset"}
         for item in items_list.items:
             DocumentNode = dataset_mapping_function(item)
             if not isinstance(DocumentNode, DocumentNode):

--- a/openagent/knowledgebase/document_loaders/asana/base.py
+++ b/openagent/knowledgebase/document_loaders/asana/base.py
@@ -51,7 +51,8 @@ class AsanaReader(BaseReader):
                             "name": task["name"],
                             "assignee": task["assignee"],
                             "project": project["name"],
-                            "workspace_id": workspace_id
+                            "workspace_id": workspace_id,
+                            "loader_key":"asana"
                         },
                     )
                 )

--- a/openagent/knowledgebase/document_loaders/asana/base.py
+++ b/openagent/knowledgebase/document_loaders/asana/base.py
@@ -52,7 +52,7 @@ class AsanaReader(BaseReader):
                             "assignee": task["assignee"],
                             "project": project["name"],
                             "workspace_id": workspace_id,
-                            "loader_key":"asana"
+                            "loader_id":"asana"
                         },
                     )
                 )

--- a/openagent/knowledgebase/document_loaders/azcognitive_search/base.py
+++ b/openagent/knowledgebase/document_loaders/azcognitive_search/base.py
@@ -67,6 +67,7 @@ class AzCognitiveSearchReader(BaseReader):
                 "query": query,
                 "content_field": content_field,
                 "filter": filter,
+                "loader_key":"azcognitive_search",
             }
             docs.append(DocumentNode(text=text, extra_info=metadata))
 

--- a/openagent/knowledgebase/document_loaders/azcognitive_search/base.py
+++ b/openagent/knowledgebase/document_loaders/azcognitive_search/base.py
@@ -67,7 +67,7 @@ class AzCognitiveSearchReader(BaseReader):
                 "query": query,
                 "content_field": content_field,
                 "filter": filter,
-                "loader_key":"azcognitive_search",
+                "loader_id":"azcognitive_search",
             }
             docs.append(DocumentNode(text=text, extra_info=metadata))
 

--- a/openagent/knowledgebase/document_loaders/bilibili/base.py
+++ b/openagent/knowledgebase/document_loaders/bilibili/base.py
@@ -54,7 +54,8 @@ class BilibiliTranscriptReader(BaseReader):
         """
         results = []
 
-        metadata = {"video_urls": video_urls}
+        metadata = {"video_urls": video_urls,
+                    "loader_key":"bilibili"}
 
         for bili_url in video_urls:
             try:

--- a/openagent/knowledgebase/document_loaders/bilibili/base.py
+++ b/openagent/knowledgebase/document_loaders/bilibili/base.py
@@ -55,7 +55,7 @@ class BilibiliTranscriptReader(BaseReader):
         results = []
 
         metadata = {"video_urls": video_urls,
-                    "loader_key":"bilibili"}
+                    "loader_id":"bilibili"}
 
         for bili_url in video_urls:
             try:

--- a/openagent/knowledgebase/document_loaders/boarddocs/base.py
+++ b/openagent/knowledgebase/document_loaders/boarddocs/base.py
@@ -100,6 +100,7 @@ class BoardDocsReader(BaseReader):
                 "title": agenda_title,
                 "date": agenda_date,
                 "url": agenda_url,
+                "loader_key":"boarddocs"
             }
         docs = []
         agenda_doc = DocumentNode(

--- a/openagent/knowledgebase/document_loaders/boarddocs/base.py
+++ b/openagent/knowledgebase/document_loaders/boarddocs/base.py
@@ -100,7 +100,7 @@ class BoardDocsReader(BaseReader):
                 "title": agenda_title,
                 "date": agenda_date,
                 "url": agenda_url,
-                "loader_key":"boarddocs"
+                "loader_id":"boarddocs"
             }
         docs = []
         agenda_doc = DocumentNode(

--- a/openagent/knowledgebase/document_loaders/chatgpt_plugin/base.py
+++ b/openagent/knowledgebase/document_loaders/chatgpt_plugin/base.py
@@ -48,7 +48,7 @@ class ChatGPTRetrievalPluginReader(BaseReader):
             "query": query,
             "tok_k": top_k,
             "separate_documents": separate_documents,
-            "loader_key":"chatgpt_plugin"
+            "loader_id":"chatgpt_plugin"
         }
         documents: List[DocumentNode] = []
         for query_result in res.json()["results"]:

--- a/openagent/knowledgebase/document_loaders/chatgpt_plugin/base.py
+++ b/openagent/knowledgebase/document_loaders/chatgpt_plugin/base.py
@@ -47,7 +47,8 @@ class ChatGPTRetrievalPluginReader(BaseReader):
             "endpoint_url": self._endpoint_url,
             "query": query,
             "tok_k": top_k,
-            "separate_documents": separate_documents
+            "separate_documents": separate_documents,
+            "loader_key":"chatgpt_plugin"
         }
         documents: List[DocumentNode] = []
         for query_result in res.json()["results"]:

--- a/openagent/knowledgebase/document_loaders/chroma/base.py
+++ b/openagent/knowledgebase/document_loaders/chroma/base.py
@@ -57,6 +57,7 @@ class ChromaReader(BaseReader):
             "collection_name": self.collection_name,
             "query_vector": query_vector,
             "limit": limit,
+            "loader_key":"chroma"
         }
         documents = []
         for result in zip(results["ids"], results["documents"], results["embeddings"]):

--- a/openagent/knowledgebase/document_loaders/chroma/base.py
+++ b/openagent/knowledgebase/document_loaders/chroma/base.py
@@ -57,7 +57,7 @@ class ChromaReader(BaseReader):
             "collection_name": self.collection_name,
             "query_vector": query_vector,
             "limit": limit,
-            "loader_key":"chroma"
+            "loader_id":"chroma"
         }
         documents = []
         for result in zip(results["ids"], results["documents"], results["embeddings"]):

--- a/openagent/knowledgebase/document_loaders/confluence/base.py
+++ b/openagent/knowledgebase/document_loaders/confluence/base.py
@@ -104,7 +104,8 @@ class ConfluenceReader(BaseReader):
         "include_attachments": include_attachments,
         "include_children": include_children,
         "limit": limit,
-        "max_num_results": max_num_results,  
+        "max_num_results": max_num_results, 
+        "loader_key":"confluence", 
     }
 
         num_space_key_parameter = 1 if space_key else 0

--- a/openagent/knowledgebase/document_loaders/confluence/base.py
+++ b/openagent/knowledgebase/document_loaders/confluence/base.py
@@ -105,7 +105,7 @@ class ConfluenceReader(BaseReader):
         "include_children": include_children,
         "limit": limit,
         "max_num_results": max_num_results, 
-        "loader_key":"confluence", 
+        "loader_id":"confluence", 
     }
 
         num_space_key_parameter = 1 if space_key else 0

--- a/openagent/knowledgebase/document_loaders/couchdb/base.py
+++ b/openagent/knowledgebase/document_loaders/couchdb/base.py
@@ -58,7 +58,7 @@ class SimpleCouchDBReader(BaseReader):
             "user": self.user,
             "db_name": db_name,
             "query": query,
-            "loader_key":"couchdb",
+            "loader_id":"couchdb",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/couchdb/base.py
+++ b/openagent/knowledgebase/document_loaders/couchdb/base.py
@@ -57,7 +57,8 @@ class SimpleCouchDBReader(BaseReader):
         metadata = {
             "user": self.user,
             "db_name": db_name,
-            "query": query
+            "query": query,
+            "loader_key":"couchdb",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/dad_jokes/base.py
+++ b/openagent/knowledgebase/document_loaders/dad_jokes/base.py
@@ -29,4 +29,5 @@ class DadJokesReader(BaseReader):
             None.
 
         """
-        return [DocumentNode(text=self._get_random_dad_joke())]
+        metadata = {"loader_key":"dad_jokes",}
+        return [DocumentNode(text=self._get_random_dad_joke(),extra_info=metadata)]

--- a/openagent/knowledgebase/document_loaders/dad_jokes/base.py
+++ b/openagent/knowledgebase/document_loaders/dad_jokes/base.py
@@ -29,5 +29,5 @@ class DadJokesReader(BaseReader):
             None.
 
         """
-        metadata = {"loader_key":"dad_jokes",}
+        metadata = {"loader_id":"dad_jokes",}
         return [DocumentNode(text=self._get_random_dad_joke(),extra_info=metadata)]

--- a/openagent/knowledgebase/document_loaders/deeplake/base.py
+++ b/openagent/knowledgebase/document_loaders/deeplake/base.py
@@ -108,7 +108,7 @@ class DeepLakeReader(BaseReader):
             "dataset_path": dataset_path,
             "limit": limit,
             "distance_metric": distance_metric,
-            "loader_key":"deep_lake",
+            "loader_id":"deep_lake",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/deeplake/base.py
+++ b/openagent/knowledgebase/document_loaders/deeplake/base.py
@@ -107,7 +107,8 @@ class DeepLakeReader(BaseReader):
             "query_vector": query_vector,
             "dataset_path": dataset_path,
             "limit": limit,
-            "distance_metric": distance_metric
+            "distance_metric": distance_metric,
+            "loader_key":"deep_lake",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/discord/base.py
+++ b/openagent/knowledgebase/document_loaders/discord/base.py
@@ -122,7 +122,8 @@ class DiscordReader(BaseReader):
         metadata = {
             "channel": channel_id,
             "limit": limit,
-            "oldest_first": oldest_first
+            "oldest_first": oldest_first,
+            "loader_key":"discord",
         }
 
         results: List[DocumentNode] = []

--- a/openagent/knowledgebase/document_loaders/discord/base.py
+++ b/openagent/knowledgebase/document_loaders/discord/base.py
@@ -123,7 +123,7 @@ class DiscordReader(BaseReader):
             "channel": channel_id,
             "limit": limit,
             "oldest_first": oldest_first,
-            "loader_key":"discord",
+            "loader_id":"discord",
         }
 
         results: List[DocumentNode] = []

--- a/openagent/knowledgebase/document_loaders/docugami/base.py
+++ b/openagent/knowledgebase/document_loaders/docugami/base.py
@@ -114,7 +114,7 @@ class DocugamiReader(BaseReader):
                 DOCUMENT_NAME_KEY: DocumentNode["name"],
                 STRUCTURE_KEY: node.attrib.get("structure", ""),
                 TAG_KEY: re.sub(r"\{.*\}", "", node.tag),
-                "loader_key":"docugami",
+                "loader_id":"docugami",
             }
 
             if doc_metadata:

--- a/openagent/knowledgebase/document_loaders/docugami/base.py
+++ b/openagent/knowledgebase/document_loaders/docugami/base.py
@@ -114,6 +114,7 @@ class DocugamiReader(BaseReader):
                 DOCUMENT_NAME_KEY: DocumentNode["name"],
                 STRUCTURE_KEY: node.attrib.get("structure", ""),
                 TAG_KEY: re.sub(r"\{.*\}", "", node.tag),
+                "loader_key":"docugami",
             }
 
             if doc_metadata:

--- a/openagent/knowledgebase/document_loaders/elasticsearch/base.py
+++ b/openagent/knowledgebase/document_loaders/elasticsearch/base.py
@@ -58,7 +58,8 @@ class ElasticsearchReader(BaseReader):
             "endpoint": self._endpoint,
             "index": self._index,
             "field": field,
-            "query": query
+            "query": query,
+            "loader_key":"elasticsearch",
         }
 
         res = self._client.post(f"{self._index}/_search", json=query).json()

--- a/openagent/knowledgebase/document_loaders/elasticsearch/base.py
+++ b/openagent/knowledgebase/document_loaders/elasticsearch/base.py
@@ -59,7 +59,7 @@ class ElasticsearchReader(BaseReader):
             "index": self._index,
             "field": field,
             "query": query,
-            "loader_key":"elasticsearch",
+            "loader_id":"elasticsearch",
         }
 
         res = self._client.post(f"{self._index}/_search", json=query).json()

--- a/openagent/knowledgebase/document_loaders/faiss/base.py
+++ b/openagent/knowledgebase/document_loaders/faiss/base.py
@@ -49,7 +49,8 @@ class FaissReader(BaseReader):
             "query": query,
             "id_to_text_map": id_to_text_map,
             "k": k,
-            "separate_documents": separate_documents
+            "separate_documents": separate_documents,
+            "loader_key":"faiss"
         }
 
         dists, indices = self._index.search(query, k)

--- a/openagent/knowledgebase/document_loaders/faiss/base.py
+++ b/openagent/knowledgebase/document_loaders/faiss/base.py
@@ -50,7 +50,7 @@ class FaissReader(BaseReader):
             "id_to_text_map": id_to_text_map,
             "k": k,
             "separate_documents": separate_documents,
-            "loader_key":"faiss"
+            "loader_id":"faiss"
         }
 
         dists, indices = self._index.search(query, k)

--- a/openagent/knowledgebase/document_loaders/feedly_rss/base.py
+++ b/openagent/knowledgebase/document_loaders/feedly_rss/base.py
@@ -50,7 +50,7 @@ class FeedlyRssReader(BaseReader):
             "directory": self.directory,
             "category": category,
             "max_count": max_count,
-            "loader_key": "feedly_rss",
+            "loader_id": "feedly_rss",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/feedly_rss/base.py
+++ b/openagent/knowledgebase/document_loaders/feedly_rss/base.py
@@ -49,7 +49,8 @@ class FeedlyRssReader(BaseReader):
         metadata = {
             "directory": self.directory,
             "category": category,
-            "max_count": max_count
+            "max_count": max_count,
+            "loader_key": "feedly_rss",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/feishu_docs/base.py
+++ b/openagent/knowledgebase/document_loaders/feishu_docs/base.py
@@ -61,7 +61,7 @@ class FeishuDocsReader(BaseReader):
         results = []
         for document_id in document_ids:
             doc = self._load_doc(document_id)
-            results.append(DocumentNode(text=doc, extra_info={"app_id": self.app_id, "document_id": document_id, "loader_key":"feishu_docs"}))
+            results.append(DocumentNode(text=doc, extra_info={"app_id": self.app_id, "document_id": document_id, "loader_id":"feishu_docs"}))
         return results
 
     def _load_doc(self, document_id) -> str:

--- a/openagent/knowledgebase/document_loaders/feishu_docs/base.py
+++ b/openagent/knowledgebase/document_loaders/feishu_docs/base.py
@@ -61,7 +61,7 @@ class FeishuDocsReader(BaseReader):
         results = []
         for document_id in document_ids:
             doc = self._load_doc(document_id)
-            results.append(DocumentNode(text=doc, extra_info={"app_id": self.app_id, "document_id": document_id, }))
+            results.append(DocumentNode(text=doc, extra_info={"app_id": self.app_id, "document_id": document_id, "loader_key":"feishu_docs"}))
         return results
 
     def _load_doc(self, document_id) -> str:

--- a/openagent/knowledgebase/document_loaders/file/audio/base.py
+++ b/openagent/knowledgebase/document_loaders/file/audio/base.py
@@ -58,4 +58,4 @@ class AudioTranscriber(BaseReader):
 
         transcript = result["text"]
 
-        return [DocumentNode(text=transcript, extra_info={**extra_info,"loader_key":"file_audio"})]
+        return [DocumentNode(text=transcript, extra_info={**extra_info,"loader_id":"file_audio"})]

--- a/openagent/knowledgebase/document_loaders/file/audio/base.py
+++ b/openagent/knowledgebase/document_loaders/file/audio/base.py
@@ -58,4 +58,4 @@ class AudioTranscriber(BaseReader):
 
         transcript = result["text"]
 
-        return [DocumentNode(text=transcript, extra_info=extra_info or {})]
+        return [DocumentNode(text=transcript, extra_info={**extra_info,"loader_key":"file_audio"})]

--- a/openagent/knowledgebase/document_loaders/file/audio_gladia/base.py
+++ b/openagent/knowledgebase/document_loaders/file/audio_gladia/base.py
@@ -94,4 +94,4 @@ class GladiaAudioTranscriber(BaseReader):
         response_dict = response.json()
         transcript = response_dict["prediction"]
 
-        return [DocumentNode(text=transcript, extra_info={**extra_info, "loader_key":"gladia_audio"})]
+        return [DocumentNode(text=transcript, extra_info={**extra_info, "loader_id":"gladia_audio"})]

--- a/openagent/knowledgebase/document_loaders/file/audio_gladia/base.py
+++ b/openagent/knowledgebase/document_loaders/file/audio_gladia/base.py
@@ -94,4 +94,4 @@ class GladiaAudioTranscriber(BaseReader):
         response_dict = response.json()
         transcript = response_dict["prediction"]
 
-        return [DocumentNode(text=transcript, extra_info=extra_info or {})]
+        return [DocumentNode(text=transcript, extra_info={**extra_info, "loader_key":"gladia_audio"})]

--- a/openagent/knowledgebase/document_loaders/file/base.py
+++ b/openagent/knowledgebase/document_loaders/file/base.py
@@ -125,7 +125,7 @@ class SimpleDirectoryReader(BaseReader):
 
         documents = []
         for input_file in self.input_files:
-            metadata = {"source": str(self.input_dir), "loader_key": "file_directory"}
+            metadata = {"source": str(self.input_dir), "loader_id": "file_directory"}
             if self.file_metadata is not None:
                 metadata = self.file_metadata(str(input_file))
 

--- a/openagent/knowledgebase/document_loaders/file/cjk_pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/cjk_pdf/base.py
@@ -72,8 +72,12 @@ class CJKPDFReader(BaseReader):
         text_list = self._extract_text_by_page(file)
 
         if self._concat_pages:
-            return [DocumentNode(text="\n".join(text_list), extra_info=extra_info or {})]
+            extra_info = extra_info or {}
+            extra_info["loader_key"] = "file_cjk_pdf"
+            return [DocumentNode(text="\n".join(text_list), extra_info=extra_info)]
         else:
+            extra_info = extra_info or {}
+            extra_info["loader_key"] = "file_cjk_pdf"
             return [
-                DocumentNode(text=text, extra_info=extra_info or {}) for text in text_list
+                DocumentNode(text=text, extra_info=extra_info ) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/cjk_pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/cjk_pdf/base.py
@@ -73,11 +73,11 @@ class CJKPDFReader(BaseReader):
 
         if self._concat_pages:
             extra_info = extra_info or {}
-            extra_info["loader_key"] = "file_cjk_pdf"
+            extra_info["loader_id"] = "file_cjk_pdf"
             return [DocumentNode(text="\n".join(text_list), extra_info=extra_info)]
         else:
             extra_info = extra_info or {}
-            extra_info["loader_key"] = "file_cjk_pdf"
+            extra_info["loader_id"] = "file_cjk_pdf"
             return [
                 DocumentNode(text=text, extra_info=extra_info ) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/deepdoctection/base.py
+++ b/openagent/knowledgebase/document_loaders/file/deepdoctection/base.py
@@ -34,6 +34,6 @@ class DeepDoctectionReader(BaseReader):
             extra_info = {
                 k: getattr(page, k) for k in self.attrs_as_metadata if hasattr(page, k)
             }
-            extra_info["loader_key"] = "deep_doctection"
+            extra_info["loader_id"] = "deep_doctection"
             result_docs.append(DocumentNode(text=doc_text, extra_info=extra_info))
         return result_docs

--- a/openagent/knowledgebase/document_loaders/file/deepdoctection/base.py
+++ b/openagent/knowledgebase/document_loaders/file/deepdoctection/base.py
@@ -34,5 +34,6 @@ class DeepDoctectionReader(BaseReader):
             extra_info = {
                 k: getattr(page, k) for k in self.attrs_as_metadata if hasattr(page, k)
             }
+            extra_info["loader_key"] = "deep_doctection"
             result_docs.append(DocumentNode(text=doc_text, extra_info=extra_info))
         return result_docs

--- a/openagent/knowledgebase/document_loaders/file/docx/base.py
+++ b/openagent/knowledgebase/document_loaders/file/docx/base.py
@@ -17,7 +17,8 @@ class DocxReader(BaseReader):
         import docx2txt
 
         text = docx2txt.process(file)
-        metadata = {"file_name": file.name}
+        metadata = {"file_name": file.name,
+                    "loader_key":"file_docx"}
 
         if extra_info is not None:
             metadata.update(extra_info)

--- a/openagent/knowledgebase/document_loaders/file/docx/base.py
+++ b/openagent/knowledgebase/document_loaders/file/docx/base.py
@@ -18,7 +18,7 @@ class DocxReader(BaseReader):
 
         text = docx2txt.process(file)
         metadata = {"file_name": file.name,
-                    "loader_key":"file_docx"}
+                    "loader_id":"file_docx"}
 
         if extra_info is not None:
             metadata.update(extra_info)

--- a/openagent/knowledgebase/document_loaders/file/epub/base.py
+++ b/openagent/knowledgebase/document_loaders/file/epub/base.py
@@ -33,4 +33,9 @@ class EpubReader(BaseReader):
                 )
 
         text = "\n".join(text_list)
+        if extra_info is None:
+            extra_info = {}
+    
+        # Add the loader_key to extra_info
+        extra_info["loader_key"] = "file_epub"
         return [DocumentNode(text=text, extra_info=extra_info or {})]

--- a/openagent/knowledgebase/document_loaders/file/epub/base.py
+++ b/openagent/knowledgebase/document_loaders/file/epub/base.py
@@ -37,5 +37,5 @@ class EpubReader(BaseReader):
             extra_info = {}
     
         # Add the loader_key to extra_info
-        extra_info["loader_key"] = "file_epub"
+        extra_info["loader_id"] = "file_epub"
         return [DocumentNode(text=text, extra_info=extra_info or {})]

--- a/openagent/knowledgebase/document_loaders/file/flat_pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/flat_pdf/base.py
@@ -58,8 +58,9 @@ class FlatPdfReader(BaseReader):
                     file=Path(work_dir + f"/page-{page_number}.png")
                 )
                 pdf_content += DocumentNode[0].text
-            return DocumentNode(text=pdf_content)
-
+            extra_info = {"loader_key": "flat_pdf"}
+            return DocumentNode(text=pdf_content, extra_info=extra_info)
+        
         except Exception as e:
             warnings.warn(f"{str(e)}")
         finally:

--- a/openagent/knowledgebase/document_loaders/file/flat_pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/flat_pdf/base.py
@@ -58,7 +58,7 @@ class FlatPdfReader(BaseReader):
                     file=Path(work_dir + f"/page-{page_number}.png")
                 )
                 pdf_content += DocumentNode[0].text
-            extra_info = {"loader_key": "flat_pdf"}
+            extra_info = {"loader_id": "flat_pdf"}
             return DocumentNode(text=pdf_content, extra_info=extra_info)
         
         except Exception as e:

--- a/openagent/knowledgebase/document_loaders/file/image/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image/base.py
@@ -111,9 +111,11 @@ class ImageReader(BaseReader):
                 model = cast(pytesseract, self._parser_config["model"])
                 text_str = model.image_to_string(image)
 
+        extra_info = {"loader_key": "image"}
         return [
             ImageDocument(
                 text=text_str,
                 image=image_str,
+                extra_info=extra_info,  # Add the loader_key to extra_info
             )
         ]

--- a/openagent/knowledgebase/document_loaders/file/image/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image/base.py
@@ -111,7 +111,7 @@ class ImageReader(BaseReader):
                 model = cast(pytesseract, self._parser_config["model"])
                 text_str = model.image_to_string(image)
 
-        extra_info = {"loader_key": "image"}
+        extra_info = {"loader_id": "image"}
         return [
             ImageDocument(
                 text=text_str,

--- a/openagent/knowledgebase/document_loaders/file/image_blip/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image_blip/base.py
@@ -101,7 +101,7 @@ class ImageCaptionReader(BaseReader):
         out = model.generate(**inputs)
         text_str = processor.decode(out[0], skip_special_tokens=True)
 
-        extra_info = {"loader_key": "image_caption"}
+        extra_info = {"loader_id": "image_caption"}
         return ImageDocument(
             text=text_str,
             image=image_str,

--- a/openagent/knowledgebase/document_loaders/file/image_blip/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image_blip/base.py
@@ -101,7 +101,9 @@ class ImageCaptionReader(BaseReader):
         out = model.generate(**inputs)
         text_str = processor.decode(out[0], skip_special_tokens=True)
 
+        extra_info = {"loader_key": "image_caption"}
         return ImageDocument(
             text=text_str,
             image=image_str,
+            extra_info=extra_info,  # Add the loader_key to extra_info
         )

--- a/openagent/knowledgebase/document_loaders/file/image_blip2/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image_blip2/base.py
@@ -95,7 +95,7 @@ class ImageVisionLLMReader(BaseReader):
         out = model.generate(**inputs)
         text_str = processor.decode(out[0], skip_special_tokens=True)
 
-        extra_info = {**extra_info, "loader_key": "image_vision"}
+        extra_info = {**extra_info, "loader_id": "image_vision"}
         return ImageDocument(
             text=text_str,
             image=image_str,

--- a/openagent/knowledgebase/document_loaders/file/image_blip2/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image_blip2/base.py
@@ -95,7 +95,9 @@ class ImageVisionLLMReader(BaseReader):
         out = model.generate(**inputs)
         text_str = processor.decode(out[0], skip_special_tokens=True)
 
+        extra_info = {**extra_info, "loader_key": "image_vision"}
         return ImageDocument(
             text=text_str,
             image=image_str,
+            extra_info=extra_info,
         )

--- a/openagent/knowledgebase/document_loaders/file/image_deplot/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image_deplot/base.py
@@ -93,6 +93,6 @@ class ImageTabularChartReader(BaseReader):
             ImageDocument(
                 text=text_str,
                 image=image_str,
-                extra_info={**extra_info,"loader_key": "image_tabular_chart"},
+                extra_info={**extra_info,"loader_id": "image_tabular_chart"},
             )
         ]

--- a/openagent/knowledgebase/document_loaders/file/image_deplot/base.py
+++ b/openagent/knowledgebase/document_loaders/file/image_deplot/base.py
@@ -93,6 +93,6 @@ class ImageTabularChartReader(BaseReader):
             ImageDocument(
                 text=text_str,
                 image=image_str,
-                extra_info=extra_info or {},
+                extra_info={**extra_info,"loader_key": "image_tabular_chart"},
             )
         ]

--- a/openagent/knowledgebase/document_loaders/file/ipynb/base.py
+++ b/openagent/knowledgebase/document_loaders/file/ipynb/base.py
@@ -39,8 +39,8 @@ class IPYNBReader(BaseReader):
         splits.pop(0)
 
         if self._concatenate:
-            docs = [DocumentNode(text="\n\n".join(splits),extra_info={**extra_info,"loader_key": "ipynb"})]
+            docs = [DocumentNode(text="\n\n".join(splits),extra_info={**extra_info,"loader_id": "ipynb"})]
         else:
-            docs = [DocumentNode(text=s, extra_info={**extra_info,"loader_key": "ipynb"}) for s in splits]
+            docs = [DocumentNode(text=s, extra_info={**extra_info,"loader_id": "ipynb"}) for s in splits]
         return docs
 

--- a/openagent/knowledgebase/document_loaders/file/ipynb/base.py
+++ b/openagent/knowledgebase/document_loaders/file/ipynb/base.py
@@ -39,7 +39,8 @@ class IPYNBReader(BaseReader):
         splits.pop(0)
 
         if self._concatenate:
-            docs = [DocumentNode(text="\n\n".join(splits))]
+            docs = [DocumentNode(text="\n\n".join(splits),extra_info={**extra_info,"loader_key": "ipynb"})]
         else:
-            docs = [DocumentNode(text=s) for s in splits]
+            docs = [DocumentNode(text=s, extra_info={**extra_info,"loader_key": "ipynb"}) for s in splits]
         return docs
+

--- a/openagent/knowledgebase/document_loaders/file/json/base.py
+++ b/openagent/knowledgebase/document_loaders/file/json/base.py
@@ -74,4 +74,4 @@ class JSONReader(BaseReader):
                 # If levels_back is set, we make the embeddings contain the labels
                 # from further up the JSON tree
                 lines = [*_depth_first_yield(data, self.levels_back, [])]
-                return [DocumentNode(text="\n".join(lines), extra_info={**extra_info, "loader_key": "json"})]
+                return [DocumentNode(text="\n".join(lines), extra_info={**extra_info, "loader_id": "json"})]

--- a/openagent/knowledgebase/document_loaders/file/json/base.py
+++ b/openagent/knowledgebase/document_loaders/file/json/base.py
@@ -74,4 +74,4 @@ class JSONReader(BaseReader):
                 # If levels_back is set, we make the embeddings contain the labels
                 # from further up the JSON tree
                 lines = [*_depth_first_yield(data, self.levels_back, [])]
-                return [DocumentNode(text="\n".join(lines), extra_info=extra_info or {})]
+                return [DocumentNode(text="\n".join(lines), extra_info={**extra_info, "loader_key": "json"})]

--- a/openagent/knowledgebase/document_loaders/file/markdown/base.py
+++ b/openagent/knowledgebase/document_loaders/file/markdown/base.py
@@ -107,4 +107,4 @@ class MarkdownReader(BaseReader):
         If content is provided, use that instead of reading from file."""
         tups = self.parse_tups(file, content=content)
         # TODO: don't include headers right now
-        return [DocumentNode(text=value, extra_info={**extra_info, "loader_key": "markdown"}) for _, value in tups]
+        return [DocumentNode(text=value, extra_info={**extra_info, "loader_id": "markdown"}) for _, value in tups]

--- a/openagent/knowledgebase/document_loaders/file/markdown/base.py
+++ b/openagent/knowledgebase/document_loaders/file/markdown/base.py
@@ -107,4 +107,4 @@ class MarkdownReader(BaseReader):
         If content is provided, use that instead of reading from file."""
         tups = self.parse_tups(file, content=content)
         # TODO: don't include headers right now
-        return [DocumentNode(text=value, extra_info=extra_info or {}) for _, value in tups]
+        return [DocumentNode(text=value, extra_info={**extra_info, "loader_key": "markdown"}) for _, value in tups]

--- a/openagent/knowledgebase/document_loaders/file/mbox/base.py
+++ b/openagent/knowledgebase/document_loaders/file/mbox/base.py
@@ -109,5 +109,5 @@ class MboxReader(BaseReader):
         docs: List[DocumentNode] = []
         content = self.parse_file(file)
         for msg in content:
-            docs.append(DocumentNode(text=msg, extra_info={**extra_info, "loader_key":"mbox"}))
+            docs.append(DocumentNode(text=msg, extra_info={**extra_info, "loader_id":"mbox"}))
         return docs

--- a/openagent/knowledgebase/document_loaders/file/mbox/base.py
+++ b/openagent/knowledgebase/document_loaders/file/mbox/base.py
@@ -109,5 +109,5 @@ class MboxReader(BaseReader):
         docs: List[DocumentNode] = []
         content = self.parse_file(file)
         for msg in content:
-            docs.append(DocumentNode(text=msg, extra_info=extra_info or {}))
+            docs.append(DocumentNode(text=msg, extra_info={**extra_info, "loader_key":"mbox"}))
         return docs

--- a/openagent/knowledgebase/document_loaders/file/paged_csv/base.py
+++ b/openagent/knowledgebase/document_loaders/file/paged_csv/base.py
@@ -42,7 +42,7 @@ class PagedCSVReader(BaseReader):
                         text="\n".join(
                             f"{k.strip()}: {v.strip()}" for k, v in row.items()
                         ),
-                        extra_info=extra_info or {},
+                        extra_info={**extra_info, "loader_key": "paged_csv"},
                     )
                 )
         return docs

--- a/openagent/knowledgebase/document_loaders/file/paged_csv/base.py
+++ b/openagent/knowledgebase/document_loaders/file/paged_csv/base.py
@@ -42,7 +42,7 @@ class PagedCSVReader(BaseReader):
                         text="\n".join(
                             f"{k.strip()}: {v.strip()}" for k, v in row.items()
                         ),
-                        extra_info={**extra_info, "loader_key": "paged_csv"},
+                        extra_info={**extra_info, "loader_id": "paged_csv"},
                     )
                 )
         return docs

--- a/openagent/knowledgebase/document_loaders/file/pandas_csv/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pandas_csv/base.py
@@ -67,11 +67,11 @@ class PandasCSVReader(BaseReader):
         if self._concat_rows:
             return [
                 DocumentNode(
-                    text=self._row_joiner.join(text_list), extra_info={**extra_info, "loader_key":"pandas_csv"}
+                    text=self._row_joiner.join(text_list), extra_info={**extra_info, "loader_id":"pandas_csv"}
 
                 )
             ]
         else:
             return [
-                DocumentNode(text=text, extra_info={**extra_info, "loader_key":"pandas_csv"}) for text in text_list
+                DocumentNode(text=text, extra_info={**extra_info, "loader_id":"pandas_csv"}) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/pandas_csv/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pandas_csv/base.py
@@ -67,10 +67,11 @@ class PandasCSVReader(BaseReader):
         if self._concat_rows:
             return [
                 DocumentNode(
-                    text=self._row_joiner.join(text_list), extra_info=extra_info or {}
+                    text=self._row_joiner.join(text_list), extra_info={**extra_info, "loader_key":"pandas_csv"}
+
                 )
             ]
         else:
             return [
-                DocumentNode(text=text, extra_info=extra_info or {}) for text in text_list
+                DocumentNode(text=text, extra_info={**extra_info, "loader_key":"pandas_csv"}) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/pandas_excel/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pandas_excel/base.py
@@ -80,10 +80,10 @@ class PandasExcelReader(BaseReader):
                     text=(self._row_joiner).join(
                         self._row_joiner.join(sublist) for sublist in text_list
                     ),
-                    extra_info=extra_info or {},
+                    extra_info={**extra_info, "loader_key":"pandas_excel"},
                 )
             ]
         else:
             return [
-                DocumentNode(text=text, extra_info=extra_info or {}) for text in text_list
+                DocumentNode(text=text, extra_info={**extra_info, "loader_key":"pandas_excel"}) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/pandas_excel/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pandas_excel/base.py
@@ -80,10 +80,10 @@ class PandasExcelReader(BaseReader):
                     text=(self._row_joiner).join(
                         self._row_joiner.join(sublist) for sublist in text_list
                     ),
-                    extra_info={**extra_info, "loader_key":"pandas_excel"},
+                    extra_info={**extra_info, "loader_id":"pandas_excel"},
                 )
             ]
         else:
             return [
-                DocumentNode(text=text, extra_info={**extra_info, "loader_key":"pandas_excel"}) for text in text_list
+                DocumentNode(text=text, extra_info={**extra_info, "loader_id":"pandas_excel"}) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pdf/base.py
@@ -29,7 +29,7 @@ class PDFReader(BaseReader):
                 # Extract the text from the page
                 page_text = pdf.pages[page].extract_text()
                 page_label = pdf.page_labels[page]
-                metadata = {"page_label": page_label, "file_name": file.name}
+                metadata = {"page_label": page_label, "file_name": file.name, "loader_key":"pdf"}
 
                 if extra_info is not None:
                     metadata.update(extra_info)

--- a/openagent/knowledgebase/document_loaders/file/pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pdf/base.py
@@ -29,7 +29,7 @@ class PDFReader(BaseReader):
                 # Extract the text from the page
                 page_text = pdf.pages[page].extract_text()
                 page_label = pdf.page_labels[page]
-                metadata = {"page_label": page_label, "file_name": file.name, "loader_key":"pdf"}
+                metadata = {"page_label": page_label, "file_name": file.name, "loader_id":"pdf"}
 
                 if extra_info is not None:
                     metadata.update(extra_info)

--- a/openagent/knowledgebase/document_loaders/file/pdf_miner/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pdf_miner/base.py
@@ -49,7 +49,7 @@ class PDFMinerReader(BaseReader):
                 # Extract the text from the page
                 page_text = _extract_text_from_page(page)
 
-                metadata = {"page_label": i, "file_name": file.name}
+                metadata = {"page_label": i, "file_name": file.name, "loader_key":"pdf_miner"}
                 if extra_info is not None:
                     metadata.update(extra_info)
 

--- a/openagent/knowledgebase/document_loaders/file/pdf_miner/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pdf_miner/base.py
@@ -49,7 +49,7 @@ class PDFMinerReader(BaseReader):
                 # Extract the text from the page
                 page_text = _extract_text_from_page(page)
 
-                metadata = {"page_label": i, "file_name": file.name, "loader_key":"pdf_miner"}
+                metadata = {"page_label": i, "file_name": file.name, "loader_id":"pdf_miner"}
                 if extra_info is not None:
                     metadata.update(extra_info)
 

--- a/openagent/knowledgebase/document_loaders/file/pptx/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pptx/base.py
@@ -103,4 +103,4 @@ class PptxReader(BaseReader):
                 if hasattr(shape, "text"):
                     result += f"{shape.text}\n"
 
-        return [DocumentNode(text=result, extra_info=extra_info or {})]
+        return [DocumentNode(text=result, extra_info={**extra_info, "loader_key":"pptx"})]

--- a/openagent/knowledgebase/document_loaders/file/pptx/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pptx/base.py
@@ -103,4 +103,4 @@ class PptxReader(BaseReader):
                 if hasattr(shape, "text"):
                     result += f"{shape.text}\n"
 
-        return [DocumentNode(text=result, extra_info={**extra_info, "loader_key":"pptx"})]
+        return [DocumentNode(text=result, extra_info={**extra_info, "loader_id":"pptx"})]

--- a/openagent/knowledgebase/document_loaders/file/pymu_pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pymu_pdf/base.py
@@ -49,6 +49,7 @@ class PyMuPDFReader(BaseReader):
                 extra_info = {}
             extra_info["total_pages"] = len(doc)
             extra_info["file_path"] = file_path
+            extra_info["loader_key"] = "pymu_pdf"
 
             # return list of documents
             return [

--- a/openagent/knowledgebase/document_loaders/file/pymu_pdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/pymu_pdf/base.py
@@ -49,7 +49,7 @@ class PyMuPDFReader(BaseReader):
                 extra_info = {}
             extra_info["total_pages"] = len(doc)
             extra_info["file_path"] = file_path
-            extra_info["loader_key"] = "pymu_pdf"
+            extra_info["loader_id"] = "pymu_pdf"
 
             # return list of documents
             return [

--- a/openagent/knowledgebase/document_loaders/file/rdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/rdf/base.py
@@ -76,4 +76,4 @@ class RDFReader(BaseReader):
 
         text = "\n".join(text_list)
 
-        return [DocumentNode(text=text, extra_info=extra_info or {})]
+        return [DocumentNode(text=text, extra_info={**extra_info, "loader_key":"rdf"})]

--- a/openagent/knowledgebase/document_loaders/file/rdf/base.py
+++ b/openagent/knowledgebase/document_loaders/file/rdf/base.py
@@ -76,4 +76,4 @@ class RDFReader(BaseReader):
 
         text = "\n".join(text_list)
 
-        return [DocumentNode(text=text, extra_info={**extra_info, "loader_key":"rdf"})]
+        return [DocumentNode(text=text, extra_info={**extra_info, "loader_id":"rdf"})]

--- a/openagent/knowledgebase/document_loaders/file/simple_csv/base.py
+++ b/openagent/knowledgebase/document_loaders/file/simple_csv/base.py
@@ -42,8 +42,8 @@ class SimpleCSVReader(BaseReader):
             for row in csv_reader:
                 text_list.append(", ".join(row))
         if self._concat_rows:
-            return [DocumentNode(text="\n".join(text_list), extra_info={**extra_info, "loader_key":"simple_csv"})]
+            return [DocumentNode(text="\n".join(text_list), extra_info={**extra_info, "loader_id":"simple_csv"})]
         else:
             return [
-                DocumentNode(text=text, extra_info={**extra_info, "loader_key":"simple_csv"}) for text in text_list
+                DocumentNode(text=text, extra_info={**extra_info, "loader_id":"simple_csv"}) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/simple_csv/base.py
+++ b/openagent/knowledgebase/document_loaders/file/simple_csv/base.py
@@ -42,8 +42,8 @@ class SimpleCSVReader(BaseReader):
             for row in csv_reader:
                 text_list.append(", ".join(row))
         if self._concat_rows:
-            return [DocumentNode(text="\n".join(text_list), extra_info=extra_info or {})]
+            return [DocumentNode(text="\n".join(text_list), extra_info={**extra_info, "loader_key":"simple_csv"})]
         else:
             return [
-                DocumentNode(text=text, extra_info=extra_info or {}) for text in text_list
+                DocumentNode(text=text, extra_info={**extra_info, "loader_key":"simple_csv"}) for text in text_list
             ]

--- a/openagent/knowledgebase/document_loaders/file/unstructured/base.py
+++ b/openagent/knowledgebase/document_loaders/file/unstructured/base.py
@@ -38,10 +38,10 @@ class UnstructuredReader(BaseReader):
 
         if split_documents:
             return [
-                DocumentNode(text=chunk, extra_info={**extra_info, "loader_key":"unstructured"})
+                DocumentNode(text=chunk, extra_info={**extra_info, "loader_id":"unstructured"})
                 for chunk in text_chunks
             ]
         else:
             return [
-                DocumentNode(text="\n\n".join(text_chunks), extra_info={**extra_info, "loader_key":"unstructured"})
+                DocumentNode(text="\n\n".join(text_chunks), extra_info={**extra_info, "loader_id":"unstructured"})
             ]

--- a/openagent/knowledgebase/document_loaders/file/unstructured/base.py
+++ b/openagent/knowledgebase/document_loaders/file/unstructured/base.py
@@ -38,10 +38,10 @@ class UnstructuredReader(BaseReader):
 
         if split_documents:
             return [
-                DocumentNode(text=chunk, extra_info=extra_info or {})
+                DocumentNode(text=chunk, extra_info={**extra_info, "loader_key":"unstructured"})
                 for chunk in text_chunks
             ]
         else:
             return [
-                DocumentNode(text="\n\n".join(text_chunks), extra_info=extra_info or {})
+                DocumentNode(text="\n\n".join(text_chunks), extra_info={**extra_info, "loader_key":"unstructured"})
             ]

--- a/openagent/knowledgebase/document_loaders/firebase_realtimedb/base.py
+++ b/openagent/knowledgebase/document_loaders/firebase_realtimedb/base.py
@@ -74,7 +74,7 @@ class FirebaseRealtimeDatabaseReader(BaseReader):
                     "databaseURL": self.database_url,
                     "path": path,
                     "field": field ,
-                    "loader_key":"firebase_realtimedb"
+                    "loader_id":"firebase_realtimedb"
                 }
                 if type(entry) is Dict and field in entry:
                   text = entry[field]

--- a/openagent/knowledgebase/document_loaders/firebase_realtimedb/base.py
+++ b/openagent/knowledgebase/document_loaders/firebase_realtimedb/base.py
@@ -73,7 +73,8 @@ class FirebaseRealtimeDatabaseReader(BaseReader):
                     "document_id": key,
                     "databaseURL": self.database_url,
                     "path": path,
-                    "field": field 
+                    "field": field ,
+                    "loader_key":"firebase_realtimedb"
                 }
                 if type(entry) is Dict and field in entry:
                   text = entry[field]

--- a/openagent/knowledgebase/document_loaders/firestore/base.py
+++ b/openagent/knowledgebase/document_loaders/firestore/base.py
@@ -43,7 +43,7 @@ class FirestoreReader(BaseReader):
         metadata = {
             "project_id": self.project_id,
             "collection": collection,
-            "loader_key": "firestore",
+            "loader_id": "firestore",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/firestore/base.py
+++ b/openagent/knowledgebase/document_loaders/firestore/base.py
@@ -42,7 +42,8 @@ class FirestoreReader(BaseReader):
 
         metadata = {
             "project_id": self.project_id,
-            "collection": collection
+            "collection": collection,
+            "loader_key": "firestore",
         }
 
         documents = []

--- a/openagent/knowledgebase/document_loaders/github_repo_issues/base.py
+++ b/openagent/knowledgebase/document_loaders/github_repo_issues/base.py
@@ -189,7 +189,7 @@ class GitHubRepositoryIssuesReader(BaseReader):
                     "url": issue["url"],
                     # source is the HTML URL, more conveninent for humans
                     "source": issue["html_url"],
-                    "loader_key":"github_repo_issues",
+                    "loader_id":"github_repo_issues",
                 }
                 if issue["closed_at"] is not None:
                     metadata["closed_at"] = issue["closed_at"]

--- a/openagent/knowledgebase/document_loaders/github_repo_issues/base.py
+++ b/openagent/knowledgebase/document_loaders/github_repo_issues/base.py
@@ -189,6 +189,7 @@ class GitHubRepositoryIssuesReader(BaseReader):
                     "url": issue["url"],
                     # source is the HTML URL, more conveninent for humans
                     "source": issue["html_url"],
+                    "loader_key":"github_repo_issues",
                 }
                 if issue["closed_at"] is not None:
                     metadata["closed_at"] = issue["closed_at"]

--- a/openagent/knowledgebase/document_loaders/gmail/base.py
+++ b/openagent/knowledgebase/document_loaders/gmail/base.py
@@ -41,7 +41,7 @@ class GmailReader(BaseReader, BaseModel):
 
         metadata = {
             "query": self.query,
-            "loader_key":"gmail",
+            "loader_id":"gmail",
         }
 
         results = []

--- a/openagent/knowledgebase/document_loaders/gmail/base.py
+++ b/openagent/knowledgebase/document_loaders/gmail/base.py
@@ -41,6 +41,7 @@ class GmailReader(BaseReader, BaseModel):
 
         metadata = {
             "query": self.query,
+            "loader_key":"gmail",
         }
 
         results = []

--- a/openagent/knowledgebase/document_loaders/google_calendar/base.py
+++ b/openagent/knowledgebase/document_loaders/google_calendar/base.py
@@ -71,7 +71,8 @@ class GoogleCalendarReader(BaseReader):
 
         metadata = {
             "number_of_results": number_of_results,
-            "start_date": start_date
+            "start_date": start_date,
+            "loader_key":"google_calendar",
         }
 
         events = events_result.get("items", [])

--- a/openagent/knowledgebase/document_loaders/google_calendar/base.py
+++ b/openagent/knowledgebase/document_loaders/google_calendar/base.py
@@ -72,7 +72,7 @@ class GoogleCalendarReader(BaseReader):
         metadata = {
             "number_of_results": number_of_results,
             "start_date": start_date,
-            "loader_key":"google_calendar",
+            "loader_id":"google_calendar",
         }
 
         events = events_result.get("items", [])

--- a/openagent/knowledgebase/document_loaders/google_docs/base.py
+++ b/openagent/knowledgebase/document_loaders/google_docs/base.py
@@ -43,7 +43,7 @@ class GoogleDocsReader(BaseReader):
         results = []
         for document_id in document_ids:
             doc = self._load_doc(document_id)
-            results.append(DocumentNode(text=doc, extra_info={"document_id": document_id}))
+            results.append(DocumentNode(text=doc, extra_info={"document_id": document_id, "loader_key": "google_docs"}))
         return results
 
     def _load_doc(self, document_id: str) -> str:

--- a/openagent/knowledgebase/document_loaders/google_docs/base.py
+++ b/openagent/knowledgebase/document_loaders/google_docs/base.py
@@ -43,7 +43,7 @@ class GoogleDocsReader(BaseReader):
         results = []
         for document_id in document_ids:
             doc = self._load_doc(document_id)
-            results.append(DocumentNode(text=doc, extra_info={"document_id": document_id, "loader_key": "google_docs"}))
+            results.append(DocumentNode(text=doc, extra_info={"document_id": document_id, "loader_id": "google_docs"}))
         return results
 
     def _load_doc(self, document_id: str) -> str:

--- a/openagent/knowledgebase/document_loaders/google_keep/base.py
+++ b/openagent/knowledgebase/document_loaders/google_keep/base.py
@@ -33,7 +33,7 @@ class GoogleKeepReader(BaseReader):
                 raise ValueError(f'Note with id {note_id} not found.')
             text = f"Title: {note.title}\nContent: {note.text}"
             results.append(DocumentNode(text=text, extra_info={"note_id":
-                                                           note_id, "loader_key": "google_keep"}))
+                                                           note_id, "loader_id": "google_keep"}))
         return results
 
     def load_all_notes(self) -> List[DocumentNode]:

--- a/openagent/knowledgebase/document_loaders/google_keep/base.py
+++ b/openagent/knowledgebase/document_loaders/google_keep/base.py
@@ -33,7 +33,7 @@ class GoogleKeepReader(BaseReader):
                 raise ValueError(f'Note with id {note_id} not found.')
             text = f"Title: {note.title}\nContent: {note.text}"
             results.append(DocumentNode(text=text, extra_info={"note_id":
-                                                           note_id}))
+                                                           note_id, "loader_key": "google_keep"}))
         return results
 
     def load_all_notes(self) -> List[DocumentNode]:

--- a/openagent/knowledgebase/document_loaders/google_sheets/base.py
+++ b/openagent/knowledgebase/document_loaders/google_sheets/base.py
@@ -60,7 +60,7 @@ class GoogleSheetsReader(BaseReader):
         for spreadsheet_id in spreadsheet_ids:
             sheet = self._load_sheet(spreadsheet_id)
             results.append(
-                DocumentNode(text=sheet, extra_info={"spreadsheet_id": spreadsheet_id})
+                DocumentNode(text=sheet, extra_info={"spreadsheet_id": spreadsheet_id, "loader_key": "google_sheets"})
             )
         return results
 

--- a/openagent/knowledgebase/document_loaders/google_sheets/base.py
+++ b/openagent/knowledgebase/document_loaders/google_sheets/base.py
@@ -60,7 +60,7 @@ class GoogleSheetsReader(BaseReader):
         for spreadsheet_id in spreadsheet_ids:
             sheet = self._load_sheet(spreadsheet_id)
             results.append(
-                DocumentNode(text=sheet, extra_info={"spreadsheet_id": spreadsheet_id, "loader_key": "google_sheets"})
+                DocumentNode(text=sheet, extra_info={"spreadsheet_id": spreadsheet_id, "loader_id": "google_sheets"})
             )
         return results
 

--- a/openagent/knowledgebase/document_loaders/gpt_repo/base.py
+++ b/openagent/knowledgebase/document_loaders/gpt_repo/base.py
@@ -117,7 +117,7 @@ class GPTRepoReader(BaseReader):
             "repo_path": repo_path,
             "preamble_str": preamble_str,
             "extensions": extensions,
-            "loader_key": "gpt_repo",
+            "loader_id": "gpt_repo",
         }
         
         ignore_file_path = os.path.join(repo_path, ".gptignore")

--- a/openagent/knowledgebase/document_loaders/gpt_repo/base.py
+++ b/openagent/knowledgebase/document_loaders/gpt_repo/base.py
@@ -116,7 +116,8 @@ class GPTRepoReader(BaseReader):
             "concatenate": self.concatenate,
             "repo_path": repo_path,
             "preamble_str": preamble_str,
-            "extensions": extensions
+            "extensions": extensions,
+            "loader_key": "gpt_repo",
         }
         
         ignore_file_path = os.path.join(repo_path, ".gptignore")

--- a/openagent/knowledgebase/document_loaders/graphdb_cypher/base.py
+++ b/openagent/knowledgebase/document_loaders/graphdb_cypher/base.py
@@ -53,7 +53,8 @@ class GraphDBCypherReader(BaseReader):
 
         metadata = {
             "query": query,
-            "parameters": parameters
+            "parameters": parameters,
+            "loader_key":"graphdb_cypher"
         }
 
         if parameters is None:

--- a/openagent/knowledgebase/document_loaders/graphdb_cypher/base.py
+++ b/openagent/knowledgebase/document_loaders/graphdb_cypher/base.py
@@ -54,7 +54,7 @@ class GraphDBCypherReader(BaseReader):
         metadata = {
             "query": query,
             "parameters": parameters,
-            "loader_key":"graphdb_cypher"
+            "loader_id":"graphdb_cypher"
         }
 
         if parameters is None:

--- a/openagent/knowledgebase/document_loaders/graphql/base.py
+++ b/openagent/knowledgebase/document_loaders/graphql/base.py
@@ -56,7 +56,8 @@ class GraphQLReader(BaseReader):
         metadata = {
             "uri": self.uri,
             "query": query,
-            "variables": variables
+            "variables": variables,
+            "loader_key": "graphql",
         }
 
         try:

--- a/openagent/knowledgebase/document_loaders/graphql/base.py
+++ b/openagent/knowledgebase/document_loaders/graphql/base.py
@@ -57,7 +57,7 @@ class GraphQLReader(BaseReader):
             "uri": self.uri,
             "query": query,
             "variables": variables,
-            "loader_key": "graphql",
+            "loader_id": "graphql",
         }
 
         try:

--- a/openagent/knowledgebase/document_loaders/hatena_blog/base.py
+++ b/openagent/knowledgebase/document_loaders/hatena_blog/base.py
@@ -36,7 +36,7 @@ class HatenaBlogReader(BaseReader):
             results.append(
                 DocumentNode(
                     text=a.content,
-                    extra_info={"title": a.title, "published": a.published, "root_endpoint": self.root_endpoint},
+                    extra_info={"title": a.title, "published": a.published, "root_endpoint": self.root_endpoint, "loader_key": "hatena_blog"},
                 )
             )
 

--- a/openagent/knowledgebase/document_loaders/hatena_blog/base.py
+++ b/openagent/knowledgebase/document_loaders/hatena_blog/base.py
@@ -36,7 +36,7 @@ class HatenaBlogReader(BaseReader):
             results.append(
                 DocumentNode(
                     text=a.content,
-                    extra_info={"title": a.title, "published": a.published, "root_endpoint": self.root_endpoint, "loader_key": "hatena_blog"},
+                    extra_info={"title": a.title, "published": a.published, "root_endpoint": self.root_endpoint, "loader_id": "hatena_blog"},
                 )
             )
 

--- a/openagent/knowledgebase/document_loaders/hubspot/base.py
+++ b/openagent/knowledgebase/document_loaders/hubspot/base.py
@@ -31,15 +31,15 @@ class HubspotReader(BaseReader):
         all_companies = api_client.crm.companies.get_all()
         results = [
             DocumentNode(
-                text=f"{all_deals}".replace("\n", ""), extra_info={"type": "deals"}
+                text=f"{all_deals}".replace("\n", ""), extra_info={"type": "deals", "loader_key": "hubspot"}
             ),
             DocumentNode(
                 text=f"{all_contacts}".replace("\n", ""),
-                extra_info={"type": "contacts"},
+                extra_info={"type": "contacts", "loader_key": "hubspot"},
             ),
             DocumentNode(
                 text=f"{all_companies}".replace("\n", ""),
-                extra_info={"type": "companies"},
+                extra_info={"type": "companies", "loader_key": "hubspot"},
             ),
         ]
         return results

--- a/openagent/knowledgebase/document_loaders/hubspot/base.py
+++ b/openagent/knowledgebase/document_loaders/hubspot/base.py
@@ -31,15 +31,15 @@ class HubspotReader(BaseReader):
         all_companies = api_client.crm.companies.get_all()
         results = [
             DocumentNode(
-                text=f"{all_deals}".replace("\n", ""), extra_info={"type": "deals", "loader_key": "hubspot"}
+                text=f"{all_deals}".replace("\n", ""), extra_info={"type": "deals", "loader_id": "hubspot"}
             ),
             DocumentNode(
                 text=f"{all_contacts}".replace("\n", ""),
-                extra_info={"type": "contacts", "loader_key": "hubspot"},
+                extra_info={"type": "contacts", "loader_id": "hubspot"},
             ),
             DocumentNode(
                 text=f"{all_companies}".replace("\n", ""),
-                extra_info={"type": "companies", "loader_key": "hubspot"},
+                extra_info={"type": "companies", "loader_id": "hubspot"},
             ),
         ]
         return results

--- a/openagent/knowledgebase/document_loaders/huggingface/fs/base.py
+++ b/openagent/knowledgebase/document_loaders/huggingface/fs/base.py
@@ -64,7 +64,7 @@ class HuggingFaceFSReader(BaseReader):
 
     def load_data(self, path: str) -> List[DocumentNode]:
         """Load data."""
-        metadata = {"path": path, "loader_key": "huggingface_fs"}
+        metadata = {"path": path, "loader_id": "huggingface_fs"}
         json_dicts = self.load_dicts(path)
         docs = []
         for d in json_dicts:

--- a/openagent/knowledgebase/document_loaders/huggingface/fs/base.py
+++ b/openagent/knowledgebase/document_loaders/huggingface/fs/base.py
@@ -64,7 +64,7 @@ class HuggingFaceFSReader(BaseReader):
 
     def load_data(self, path: str) -> List[DocumentNode]:
         """Load data."""
-        metadata = {"path": path}
+        metadata = {"path": path, "loader_key": "huggingface_fs"}
         json_dicts = self.load_dicts(path)
         docs = []
         for d in json_dicts:

--- a/openagent/knowledgebase/document_loaders/intercom/base.py
+++ b/openagent/knowledgebase/document_loaders/intercom/base.py
@@ -42,6 +42,7 @@ class IntercomReader(BaseReader):
                 "title": article["title"],
                 "url": article["url"],
                 "updated_at": article["updated_at"],
+                "loader_key":"intercom",
             }
 
             results.append(

--- a/openagent/knowledgebase/document_loaders/intercom/base.py
+++ b/openagent/knowledgebase/document_loaders/intercom/base.py
@@ -42,7 +42,7 @@ class IntercomReader(BaseReader):
                 "title": article["title"],
                 "url": article["url"],
                 "updated_at": article["updated_at"],
-                "loader_key":"intercom",
+                "loader_id":"intercom",
             }
 
             results.append(

--- a/openagent/knowledgebase/document_loaders/jira/base.py
+++ b/openagent/knowledgebase/document_loaders/jira/base.py
@@ -87,6 +87,7 @@ class JiraReader(BaseReader):
                                 "epic_key": epic_key,
                                 "epic_summary": epic_summary,
                                 "epic_description": epic_descripton,
+                                "loader_key":"jira",
                             }
                         ),
                     )

--- a/openagent/knowledgebase/document_loaders/jira/base.py
+++ b/openagent/knowledgebase/document_loaders/jira/base.py
@@ -87,7 +87,7 @@ class JiraReader(BaseReader):
                                 "epic_key": epic_key,
                                 "epic_summary": epic_summary,
                                 "epic_description": epic_descripton,
-                                "loader_key":"jira",
+                                "loader_id":"jira",
                             }
                         ),
                     )

--- a/openagent/knowledgebase/document_loaders/joplin/base.py
+++ b/openagent/knowledgebase/document_loaders/joplin/base.py
@@ -95,7 +95,7 @@ class JoplinReader(BaseReader):
                         "title": note["title"],
                         "created_time": self._convert_date(note["created_time"]),
                         "updated_time": self._convert_date(note["updated_time"]),
-                        "loader_key":"joplin"
+                        "loader_id":"joplin"
                     }
                     if self.parse_markdown:
                         yield from self.parser.load_data(

--- a/openagent/knowledgebase/document_loaders/joplin/base.py
+++ b/openagent/knowledgebase/document_loaders/joplin/base.py
@@ -95,6 +95,7 @@ class JoplinReader(BaseReader):
                         "title": note["title"],
                         "created_time": self._convert_date(note["created_time"]),
                         "updated_time": self._convert_date(note["updated_time"]),
+                        "loader_key":"joplin"
                     }
                     if self.parse_markdown:
                         yield from self.parser.load_data(

--- a/openagent/knowledgebase/document_loaders/jsondata/base.py
+++ b/openagent/knowledgebase/document_loaders/jsondata/base.py
@@ -45,7 +45,7 @@ class JSONDataReader(BaseReader):
         """Load data from the input file."""
         metadata = {
             "input_data": input_data,
-            "loader_key":"jsondata",
+            "loader_id":"jsondata",
         }
         if isinstance(input_data, str):
             data = json.loads(input_data)

--- a/openagent/knowledgebase/document_loaders/jsondata/base.py
+++ b/openagent/knowledgebase/document_loaders/jsondata/base.py
@@ -44,7 +44,8 @@ class JSONDataReader(BaseReader):
     def load_data(self, input_data: Union[str, Dict]) -> List[DocumentNode]:
         """Load data from the input file."""
         metadata = {
-            "input_data": input_data
+            "input_data": input_data,
+            "loader_key":"jsondata",
         }
         if isinstance(input_data, str):
             data = json.loads(input_data)

--- a/openagent/knowledgebase/document_loaders/kaltura/esearch/base.py
+++ b/openagent/knowledgebase/document_loaders/kaltura/esearch/base.py
@@ -142,7 +142,7 @@ class KalturaESearchReader(BaseReader):
                     entry_dict = entry_info.copy()
                     entry_info = {"entry_id": str(entry.id)}
 
-                entry_doc = DocumentNode(text=json.dumps(entry_dict), extra_info={**entry_info, "loader_key":"kaltura_esearch"})
+                entry_doc = DocumentNode(text=json.dumps(entry_dict), extra_info={**entry_info, "loader_id":"kaltura_esearch"})
                 entries.append(entry_doc)
 
             return entries

--- a/openagent/knowledgebase/document_loaders/kaltura/esearch/base.py
+++ b/openagent/knowledgebase/document_loaders/kaltura/esearch/base.py
@@ -142,7 +142,7 @@ class KalturaESearchReader(BaseReader):
                     entry_dict = entry_info.copy()
                     entry_info = {"entry_id": str(entry.id)}
 
-                entry_doc = DocumentNode(text=json.dumps(entry_dict), extra_info=entry_info)
+                entry_doc = DocumentNode(text=json.dumps(entry_dict), extra_info={**entry_info, "loader_key":"kaltura_esearch"})
                 entries.append(entry_doc)
 
             return entries

--- a/openagent/knowledgebase/document_loaders/kibela/base.py
+++ b/openagent/knowledgebase/document_loaders/kibela/base.py
@@ -91,7 +91,7 @@ class KibelaReader(BaseReader):
         metadata ={
             "team": self.team,
             "url": self.url,
-            "loader_key":"kibela",
+            "loader_id":"kibela",
         }
 
         params = {"after": ""}

--- a/openagent/knowledgebase/document_loaders/kibela/base.py
+++ b/openagent/knowledgebase/document_loaders/kibela/base.py
@@ -90,7 +90,8 @@ class KibelaReader(BaseReader):
         """
         metadata ={
             "team": self.team,
-            "url": self.url
+            "url": self.url,
+            "loader_key":"kibela",
         }
 
         params = {"after": ""}

--- a/openagent/knowledgebase/document_loaders/mangoapps_guides/base.py
+++ b/openagent/knowledgebase/document_loaders/mangoapps_guides/base.py
@@ -89,7 +89,7 @@ class MangoppsGuidesReader(BaseReader):
                 print(f"Failed for {url} => {e}")
 
         for k, v in guides_pages.items():
-            metadata = {"url": k, "title": v["title"], "loader_key":"mangoapps_guides"}
+            metadata = {"url": k, "title": v["title"], "loader_id":"mangoapps_guides"}
             results.append(
                 DocumentNode(
                     text=v["text"],

--- a/openagent/knowledgebase/document_loaders/mangoapps_guides/base.py
+++ b/openagent/knowledgebase/document_loaders/mangoapps_guides/base.py
@@ -89,7 +89,7 @@ class MangoppsGuidesReader(BaseReader):
                 print(f"Failed for {url} => {e}")
 
         for k, v in guides_pages.items():
-            metadata = {"url": k, "title": v["title"]}
+            metadata = {"url": k, "title": v["title"], "loader_key":"mangoapps_guides"}
             results.append(
                 DocumentNode(
                     text=v["text"],

--- a/openagent/knowledgebase/document_loaders/maps/base.py
+++ b/openagent/knowledgebase/document_loaders/maps/base.py
@@ -103,7 +103,7 @@ class OpenMap(BaseReader):
         )
 
         metadata["overpass_query"] = query
-        metadata["loader_key"]="maps"
+        metadata["loader_id"]="maps"
         try:
             response = overpass.request(query)
 

--- a/openagent/knowledgebase/document_loaders/maps/base.py
+++ b/openagent/knowledgebase/document_loaders/maps/base.py
@@ -103,6 +103,7 @@ class OpenMap(BaseReader):
         )
 
         metadata["overpass_query"] = query
+        metadata["loader_key"]="maps"
         try:
             response = overpass.request(query)
 

--- a/openagent/knowledgebase/document_loaders/memos/base.py
+++ b/openagent/knowledgebase/document_loaders/memos/base.py
@@ -54,7 +54,7 @@ class MemosReader(BaseReader):
                 "creator": memo["creator"],
                 "resource_list": memo["resourceList"],
                 id: memo["id"],
-                "loader_key":"memos",
+                "loader_id":"memos",
             }
             documents.append(DocumentNode(text=content, extra_info=metadata))
 

--- a/openagent/knowledgebase/document_loaders/memos/base.py
+++ b/openagent/knowledgebase/document_loaders/memos/base.py
@@ -54,6 +54,7 @@ class MemosReader(BaseReader):
                 "creator": memo["creator"],
                 "resource_list": memo["resourceList"],
                 id: memo["id"],
+                "loader_key":"memos",
             }
             documents.append(DocumentNode(text=content, extra_info=metadata))
 

--- a/openagent/knowledgebase/document_loaders/metal/base.py
+++ b/openagent/knowledgebase/document_loaders/metal/base.py
@@ -56,7 +56,8 @@ class MetalReader(BaseReader):
             "limit": limit,
             "query_embedding": query_embedding,
             "filters": filters,
-            "separate_documents": separate_documents
+            "separate_documents": separate_documents,
+            "loader_key":"metal",
         }
 
         payload = {

--- a/openagent/knowledgebase/document_loaders/metal/base.py
+++ b/openagent/knowledgebase/document_loaders/metal/base.py
@@ -57,7 +57,7 @@ class MetalReader(BaseReader):
             "query_embedding": query_embedding,
             "filters": filters,
             "separate_documents": separate_documents,
-            "loader_key":"metal",
+            "loader_id":"metal",
         }
 
         payload = {

--- a/openagent/knowledgebase/document_loaders/milvus/base.py
+++ b/openagent/knowledgebase/document_loaders/milvus/base.py
@@ -78,7 +78,8 @@ class MilvusReader(BaseReader):
             "collection_name": collection_name,
             "expr": expr,
             "search_params": search_params,
-            "limit": limit
+            "limit": limit,
+            "loader_key":"milvus",
         }
 
         from pymilvus import Collection, MilvusException

--- a/openagent/knowledgebase/document_loaders/milvus/base.py
+++ b/openagent/knowledgebase/document_loaders/milvus/base.py
@@ -79,7 +79,7 @@ class MilvusReader(BaseReader):
             "expr": expr,
             "search_params": search_params,
             "limit": limit,
-            "loader_key":"milvus",
+            "loader_id":"milvus",
         }
 
         from pymilvus import Collection, MilvusException

--- a/openagent/knowledgebase/document_loaders/mondaydotcom/base.py
+++ b/openagent/knowledgebase/document_loaders/mondaydotcom/base.py
@@ -81,7 +81,7 @@ class MondayReader(BaseReader):
                     text += f", {item_value['title']}: {item_value['value']}"
             result.append(
                 DocumentNode(
-                    text=text, extra_info={"board_id": board_id, "item_id": item["id"], "loader_key":"mondaydotcom"} 
+                    text=text, extra_info={"board_id": board_id, "item_id": item["id"], "loader_id":"mondaydotcom"} 
                 )
             )
 

--- a/openagent/knowledgebase/document_loaders/mondaydotcom/base.py
+++ b/openagent/knowledgebase/document_loaders/mondaydotcom/base.py
@@ -81,7 +81,7 @@ class MondayReader(BaseReader):
                     text += f", {item_value['title']}: {item_value['value']}"
             result.append(
                 DocumentNode(
-                    text=text, extra_info={"board_id": board_id, "item_id": item["id"]}
+                    text=text, extra_info={"board_id": board_id, "item_id": item["id"], "loader_key":"mondaydotcom"} 
                 )
             )
 

--- a/openagent/knowledgebase/document_loaders/mongo/base.py
+++ b/openagent/knowledgebase/document_loaders/mongo/base.py
@@ -68,7 +68,7 @@ class SimpleMongoReader(BaseReader):
             "db_name": db_name,
             "collection_name": collection_name,
             "query_dict": query_dict,
-            "loader_key":"mongo",
+            "loader_id":"mongo",
         }
         documents = []
         db = self.client[db_name]

--- a/openagent/knowledgebase/document_loaders/mongo/base.py
+++ b/openagent/knowledgebase/document_loaders/mongo/base.py
@@ -67,7 +67,8 @@ class SimpleMongoReader(BaseReader):
             "uri": self.uri,
             "db_name": db_name,
             "collection_name": collection_name,
-            "query_dict": query_dict
+            "query_dict": query_dict,
+            "loader_key":"mongo",
         }
         documents = []
         db = self.client[db_name]

--- a/openagent/knowledgebase/document_loaders/notion/base.py
+++ b/openagent/knowledgebase/document_loaders/notion/base.py
@@ -165,11 +165,11 @@ class NotionPageReader(BaseReader):
             page_ids = self.query_database(database_id)
             for page_id in page_ids:
                 page_text = self.read_page(page_id)
-                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id}))
+                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id, "loader_key": "notion"}))
         else:
             for page_id in page_ids:
                 page_text = self.read_page(page_id)
-                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id}))
+                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id, "loader_key": "notion"}))
 
         return docs
 

--- a/openagent/knowledgebase/document_loaders/notion/base.py
+++ b/openagent/knowledgebase/document_loaders/notion/base.py
@@ -165,11 +165,11 @@ class NotionPageReader(BaseReader):
             page_ids = self.query_database(database_id)
             for page_id in page_ids:
                 page_text = self.read_page(page_id)
-                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id, "loader_key": "notion"}))
+                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id, "loader_id": "notion"}))
         else:
             for page_id in page_ids:
                 page_text = self.read_page(page_id)
-                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id, "loader_key": "notion"}))
+                docs.append(DocumentNode(text=page_text, extra_info={"page_id": page_id, "database_id": database_id, "loader_id": "notion"}))
 
         return docs
 

--- a/openagent/knowledgebase/document_loaders/obsidian/base.py
+++ b/openagent/knowledgebase/document_loaders/obsidian/base.py
@@ -37,7 +37,7 @@ class ObsidianReader(BaseReader):
                     filepath = os.path.join(dirpath, filename)
                     content = MarkdownReader().load_data(Path(filepath))
 
-                    metadata = {"input_dir": self.input_dir, "loader_key":"obsidian"}
+                    metadata = {"input_dir": self.input_dir, "loader_id":"obsidian"}
 
                     for doc in content:
                         doc.extra_info = metadata  

--- a/openagent/knowledgebase/document_loaders/obsidian/base.py
+++ b/openagent/knowledgebase/document_loaders/obsidian/base.py
@@ -37,7 +37,7 @@ class ObsidianReader(BaseReader):
                     filepath = os.path.join(dirpath, filename)
                     content = MarkdownReader().load_data(Path(filepath))
 
-                    metadata = {"input_dir": self.input_dir}
+                    metadata = {"input_dir": self.input_dir, "loader_key":"obsidian"}
 
                     for doc in content:
                         doc.extra_info = metadata  

--- a/openagent/knowledgebase/document_loaders/opendal_reader/azblob/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/azblob/base.py
@@ -69,4 +69,10 @@ class OpendalAzblobReader(BaseReader):
             **self.options,
         )
 
-        return loader.load_data()
+        # creating the DocumentNode
+        documents = loader.load_data()
+        # Add the loader_key to extra_info for each document
+        for doc in documents:
+            doc.extra_info = {**doc.extra_info, "loader_key": "opendal_azblob"}
+
+        return documents

--- a/openagent/knowledgebase/document_loaders/opendal_reader/azblob/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/azblob/base.py
@@ -71,8 +71,8 @@ class OpendalAzblobReader(BaseReader):
 
         # creating the DocumentNode
         documents = loader.load_data()
-        # Add the loader_key to extra_info for each document
+        # Add the loader_id to extra_info for each document
         for doc in documents:
-            doc.extra_info = {**doc.extra_info, "loader_key": "opendal_azblob"}
+            doc.extra_info = {**doc.extra_info, "loader_id": "opendal_azblob"}
 
         return documents

--- a/openagent/knowledgebase/document_loaders/opendal_reader/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/base.py
@@ -60,7 +60,13 @@ class OpendalReader(BaseReader):
                 SimpleDirectoryReader = download_loader("SimpleDirectoryReader")
             loader = SimpleDirectoryReader(temp_dir, file_extractor=self.file_extractor)
 
-            return loader.load_data()
+            documents = loader.load_data()
+
+            # Add "loader_key" to extra_info for all documents
+            for doc in documents:
+                doc.extra_info = {"loader_key": "opendal"}
+
+            return documents
 
 
 async def download_file_from_opendal(op: Any, temp_dir: str, path: str) -> str:

--- a/openagent/knowledgebase/document_loaders/opendal_reader/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/base.py
@@ -62,9 +62,9 @@ class OpendalReader(BaseReader):
 
             documents = loader.load_data()
 
-            # Add "loader_key" to extra_info for all documents
+            # Add "loader_id" to extra_info for all documents
             for doc in documents:
-                doc.extra_info = {"loader_key": "opendal"}
+                doc.extra_info = {"loader_id": "opendal"}
 
             return documents
 

--- a/openagent/knowledgebase/document_loaders/opendal_reader/gcs/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/gcs/base.py
@@ -65,4 +65,9 @@ class OpendalGcsReader(BaseReader):
             **self.options,
         )
 
-        return loader.load_data()
+        # Load documents and add the "loader_key" to extra_info
+        documents = loader.load_data()
+        for doc in documents:
+            doc.extra_info = {"loader_key": "opendal_gcs"}
+
+        return documents

--- a/openagent/knowledgebase/document_loaders/opendal_reader/gcs/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/gcs/base.py
@@ -65,9 +65,9 @@ class OpendalGcsReader(BaseReader):
             **self.options,
         )
 
-        # Load documents and add the "loader_key" to extra_info
+        # Load documents and add the "loader_id" to extra_info
         documents = loader.load_data()
         for doc in documents:
-            doc.extra_info = {"loader_key": "opendal_gcs"}
+            doc.extra_info = {"loader_id": "opendal_gcs"}
 
         return documents

--- a/openagent/knowledgebase/document_loaders/opendal_reader/s3/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/s3/base.py
@@ -70,4 +70,9 @@ class OpendalS3Reader(BaseReader):
             **self.options,
         )
 
-        return loader.load_data()
+        # Load documents and add the "loader_key" to extra_info
+        documents = loader.load_data()
+        for doc in documents:
+            doc.extra_info = {"loader_key": "opendal_s3"}
+
+        return documents

--- a/openagent/knowledgebase/document_loaders/opendal_reader/s3/base.py
+++ b/openagent/knowledgebase/document_loaders/opendal_reader/s3/base.py
@@ -70,9 +70,9 @@ class OpendalS3Reader(BaseReader):
             **self.options,
         )
 
-        # Load documents and add the "loader_key" to extra_info
+        # Load documents and add the "loader_id" to extra_info
         documents = loader.load_data()
         for doc in documents:
-            doc.extra_info = {"loader_key": "opendal_s3"}
+            doc.extra_info = {"loader_id": "opendal_s3"}
 
         return documents

--- a/openagent/knowledgebase/document_loaders/outlook_localcalendar/base.py
+++ b/openagent/knowledgebase/document_loaders/outlook_localcalendar/base.py
@@ -62,7 +62,7 @@ class OutlookLocalCalendarReader(BaseReader):
             "start_date": start_date,
             "end_date": end_date,
             "more_attributes": more_attributes,
-            "loader_key":"outlook_localcalendar",
+            "loader_id":"outlook_localcalendar",
         }
 
         if platform.system().lower() != "windows":

--- a/openagent/knowledgebase/document_loaders/outlook_localcalendar/base.py
+++ b/openagent/knowledgebase/document_loaders/outlook_localcalendar/base.py
@@ -61,7 +61,8 @@ class OutlookLocalCalendarReader(BaseReader):
             "number_of_results": number_of_results,
             "start_date": start_date,
             "end_date": end_date,
-            "more_attributes": more_attributes
+            "more_attributes": more_attributes,
+            "loader_key":"outlook_localcalendar",
         }
 
         if platform.system().lower() != "windows":

--- a/openagent/knowledgebase/document_loaders/papers/pubmed/base.py
+++ b/openagent/knowledgebase/document_loaders/papers/pubmed/base.py
@@ -84,6 +84,7 @@ class PubmedReader(BaseReader):
                             "Date published": datetime.strptime(
                                 paper["date"], "%Y%m%d"
                             ).strftime("%m/%d/%Y"),
+                            "loader_key": "pubmed"
                         },
                     )
                 )
@@ -162,7 +163,8 @@ class PubmedReader(BaseReader):
                         "Journal it was published in:": paper["journal"],
                         "URL": paper["url"],
                         "search_query": search_query,
-                        "max_results": max_results
+                        "max_results": max_results,
+                        "loader_key":"pubmed",
                     },
                 )
             )

--- a/openagent/knowledgebase/document_loaders/papers/pubmed/base.py
+++ b/openagent/knowledgebase/document_loaders/papers/pubmed/base.py
@@ -84,7 +84,7 @@ class PubmedReader(BaseReader):
                             "Date published": datetime.strptime(
                                 paper["date"], "%Y%m%d"
                             ).strftime("%m/%d/%Y"),
-                            "loader_key": "pubmed"
+                            "loader_id": "pubmed"
                         },
                     )
                 )

--- a/openagent/knowledgebase/document_loaders/pinecone/base.py
+++ b/openagent/knowledgebase/document_loaders/pinecone/base.py
@@ -58,7 +58,7 @@ class PineconeReader(BaseReader):
             "top k": top_k,
             "separate_documents": separate_documents,
             "include_values": include_values,
-            "loader_key":"pinecone",
+            "loader_id":"pinecone",
         }
 
         import pinecone

--- a/openagent/knowledgebase/document_loaders/pinecone/base.py
+++ b/openagent/knowledgebase/document_loaders/pinecone/base.py
@@ -57,7 +57,8 @@ class PineconeReader(BaseReader):
             "vector": vector,
             "top k": top_k,
             "separate_documents": separate_documents,
-            "include_values": include_values
+            "include_values": include_values,
+            "loader_key":"pinecone",
         }
 
         import pinecone

--- a/openagent/knowledgebase/document_loaders/qdrant/base.py
+++ b/openagent/knowledgebase/document_loaders/qdrant/base.py
@@ -126,7 +126,7 @@ class QdrantReader(BaseReader):
             "must_not_search_mapping": must_not_search_mapping,
             "rang_search_mapping": rang_search_mapping,
             "limit": limit,
-            "loader_key":"qdrant",
+            "loader_id":"qdrant",
         }
 
         from qdrant_client.http.models.models import Payload

--- a/openagent/knowledgebase/document_loaders/qdrant/base.py
+++ b/openagent/knowledgebase/document_loaders/qdrant/base.py
@@ -125,7 +125,8 @@ class QdrantReader(BaseReader):
             "must_search_mapping": must_search_mapping,
             "must_not_search_mapping": must_not_search_mapping,
             "rang_search_mapping": rang_search_mapping,
-            "limit": limit
+            "limit": limit,
+            "loader_key":"qdrant",
         }
 
         from qdrant_client.http.models.models import Payload

--- a/openagent/knowledgebase/document_loaders/readwise/base.py
+++ b/openagent/knowledgebase/document_loaders/readwise/base.py
@@ -55,7 +55,8 @@ class ReadwiseReader(BaseReader):
             updated_after (datetime.datetime): The datetime to load highlights after. Useful for updating indexes over time.
         """
         metadata = {
-            "updated_after": updated_after
+            "updated_after": updated_after,
+            "loader_key":"readwise",
         }
 
         readwise_response = _get_readwise_data(

--- a/openagent/knowledgebase/document_loaders/readwise/base.py
+++ b/openagent/knowledgebase/document_loaders/readwise/base.py
@@ -56,7 +56,7 @@ class ReadwiseReader(BaseReader):
         """
         metadata = {
             "updated_after": updated_after,
-            "loader_key":"readwise",
+            "loader_id":"readwise",
         }
 
         readwise_response = _get_readwise_data(

--- a/openagent/knowledgebase/document_loaders/reddit/base.py
+++ b/openagent/knowledgebase/document_loaders/reddit/base.py
@@ -52,7 +52,7 @@ class RedditReader(BaseReader):
                         "subreddits": sr,
                         "search_keys": kw,
                         "post_limit": post_limit,
-                        "loader_key":"reddit",
+                        "loader_id":"reddit",
                     }
                     posts.append(DocumentNode(text=post.selftext, extra_info=metadata))
                     for top_level_comment in post.comments:
@@ -62,7 +62,7 @@ class RedditReader(BaseReader):
                         "subreddits": sr,
                         "search_keys": kw,
                         "post_limit": post_limit,
-                        "loader_key":"reddit",
+                        "loader_id":"reddit",
                     }
                         posts.append(DocumentNode(text=top_level_comment.body, extra_info=metadata))
 

--- a/openagent/knowledgebase/document_loaders/reddit/base.py
+++ b/openagent/knowledgebase/document_loaders/reddit/base.py
@@ -51,7 +51,8 @@ class RedditReader(BaseReader):
                     metadata = {
                         "subreddits": sr,
                         "search_keys": kw,
-                        "post_limit": post_limit
+                        "post_limit": post_limit,
+                        "loader_key":"reddit",
                     }
                     posts.append(DocumentNode(text=post.selftext, extra_info=metadata))
                     for top_level_comment in post.comments:
@@ -60,7 +61,8 @@ class RedditReader(BaseReader):
                         metadata = {
                         "subreddits": sr,
                         "search_keys": kw,
-                        "post_limit": post_limit
+                        "post_limit": post_limit,
+                        "loader_key":"reddit",
                     }
                         posts.append(DocumentNode(text=top_level_comment.body, extra_info=metadata))
 

--- a/openagent/knowledgebase/document_loaders/slack/base.py
+++ b/openagent/knowledgebase/document_loaders/slack/base.py
@@ -179,7 +179,7 @@ class SlackReader(BaseReader):
                 channel_id, reverse_chronological=reverse_chronological
             )
             results.append(
-                DocumentNode(text=channel_content, extra_info={"channel": channel_id})
+                DocumentNode(text=channel_content, extra_info={"channel": channel_id, "loader_key":"slack"})
             )
         return results
 

--- a/openagent/knowledgebase/document_loaders/slack/base.py
+++ b/openagent/knowledgebase/document_loaders/slack/base.py
@@ -179,7 +179,7 @@ class SlackReader(BaseReader):
                 channel_id, reverse_chronological=reverse_chronological
             )
             results.append(
-                DocumentNode(text=channel_content, extra_info={"channel": channel_id, "loader_key":"slack"})
+                DocumentNode(text=channel_content, extra_info={"channel": channel_id, "loader_id":"slack"})
             )
         return results
 

--- a/openagent/knowledgebase/document_loaders/snscrape_twitter/base.py
+++ b/openagent/knowledgebase/document_loaders/snscrape_twitter/base.py
@@ -34,4 +34,4 @@ class SnscrapeTwitterReader(BaseReader):
             if i > num_tweets:
                 break
             attributes_container.append(tweet.rawContent)
-        return [DocumentNode(text=attributes_container, extra_info={"username": username, "num_tweets": num_tweets, "loader_key":"snscrape_twitter"})]
+        return [DocumentNode(text=attributes_container, extra_info={"username": username, "num_tweets": num_tweets, "loader_id":"snscrape_twitter"})]

--- a/openagent/knowledgebase/document_loaders/snscrape_twitter/base.py
+++ b/openagent/knowledgebase/document_loaders/snscrape_twitter/base.py
@@ -34,4 +34,4 @@ class SnscrapeTwitterReader(BaseReader):
             if i > num_tweets:
                 break
             attributes_container.append(tweet.rawContent)
-        return [DocumentNode(text=attributes_container, extra_info={"username": username, "num_tweets": num_tweets})]
+        return [DocumentNode(text=attributes_container, extra_info={"username": username, "num_tweets": num_tweets, "loader_key":"snscrape_twitter"})]

--- a/openagent/knowledgebase/document_loaders/spotify/base.py
+++ b/openagent/knowledgebase/document_loaders/spotify/base.py
@@ -36,7 +36,7 @@ class SpotifyReader(BaseReader):
                 album_name = album["name"]
                 artist_name = album["artists"][0]["name"]
                 album_string = f"Album {album_name} by Artist {artist_name}\n"
-                results.append(DocumentNode(text=album_string, extra_info={"collection": "albums"}))
+                results.append(DocumentNode(text=album_string, extra_info={"collection": "albums", "loader_key":"spotify"}))
         elif collection == "tracks":
             response = sp.current_user_saved_tracks()
             items = response["items"]
@@ -45,7 +45,7 @@ class SpotifyReader(BaseReader):
                 track_name = track["name"]
                 artist_name = track["artists"][0]["name"]
                 artist_string = f"Track {track_name} by Artist {artist_name}\n"
-                results.append(DocumentNode(text=artist_string, extra_info={"collection": "tracks"}))
+                results.append(DocumentNode(text=artist_string, extra_info={"collection": "tracks", "loader_key":"spotify"}))
         elif collection == "playlists":
             response = sp.current_user_playlists()
             items = response["items"]
@@ -53,7 +53,7 @@ class SpotifyReader(BaseReader):
                 playlist_name = item["name"]
                 owner_name = item["owner"]["display_name"]
                 playlist_string = f"Playlist {playlist_name} created by {owner_name}\n"
-                results.append(DocumentNode(text=playlist_string, extra_info={"collection": "playlists"}))
+                results.append(DocumentNode(text=playlist_string, extra_info={"collection": "playlists", "loader_key":"spotify"}))
         else:
             raise ValueError(
                 "Invalid collection parameter value. Allowed values are 'albums', 'tracks', or 'playlists'."

--- a/openagent/knowledgebase/document_loaders/spotify/base.py
+++ b/openagent/knowledgebase/document_loaders/spotify/base.py
@@ -36,7 +36,7 @@ class SpotifyReader(BaseReader):
                 album_name = album["name"]
                 artist_name = album["artists"][0]["name"]
                 album_string = f"Album {album_name} by Artist {artist_name}\n"
-                results.append(DocumentNode(text=album_string, extra_info={"collection": "albums", "loader_key":"spotify"}))
+                results.append(DocumentNode(text=album_string, extra_info={"collection": "albums", "loader_id":"spotify"}))
         elif collection == "tracks":
             response = sp.current_user_saved_tracks()
             items = response["items"]
@@ -45,7 +45,7 @@ class SpotifyReader(BaseReader):
                 track_name = track["name"]
                 artist_name = track["artists"][0]["name"]
                 artist_string = f"Track {track_name} by Artist {artist_name}\n"
-                results.append(DocumentNode(text=artist_string, extra_info={"collection": "tracks", "loader_key":"spotify"}))
+                results.append(DocumentNode(text=artist_string, extra_info={"collection": "tracks", "loader_id":"spotify"}))
         elif collection == "playlists":
             response = sp.current_user_playlists()
             items = response["items"]
@@ -53,7 +53,7 @@ class SpotifyReader(BaseReader):
                 playlist_name = item["name"]
                 owner_name = item["owner"]["display_name"]
                 playlist_string = f"Playlist {playlist_name} created by {owner_name}\n"
-                results.append(DocumentNode(text=playlist_string, extra_info={"collection": "playlists", "loader_key":"spotify"}))
+                results.append(DocumentNode(text=playlist_string, extra_info={"collection": "playlists", "loader_id":"spotify"}))
         else:
             raise ValueError(
                 "Invalid collection parameter value. Allowed values are 'albums', 'tracks', or 'playlists'."

--- a/openagent/knowledgebase/document_loaders/stackoverflow/base.py
+++ b/openagent/knowledgebase/document_loaders/stackoverflow/base.py
@@ -148,7 +148,7 @@ class StackoverflowReader(BaseReader):
                         "url": post.link,
                         "author_image_url": post.owner_profile_image,
                         "type": post.post_type,
-                        "loader_key":"stackoverflow"
+                        "loader_id":"stackoverflow"
                     },
                 )
                 data.append(post_document)

--- a/openagent/knowledgebase/document_loaders/stackoverflow/base.py
+++ b/openagent/knowledgebase/document_loaders/stackoverflow/base.py
@@ -148,6 +148,7 @@ class StackoverflowReader(BaseReader):
                         "url": post.link,
                         "author_image_url": post.owner_profile_image,
                         "type": post.post_type,
+                        "loader_key":"stackoverflow"
                     },
                 )
                 data.append(post_document)

--- a/openagent/knowledgebase/document_loaders/steamship/base.py
+++ b/openagent/knowledgebase/document_loaders/steamship/base.py
@@ -76,7 +76,8 @@ class SteamshipFileReader(BaseReader):
                 "workspace": workspace,
                 "query": query,
                 "collapse_blocks": collapse_blocks,
-                "join_str": join_str
+                "join_str": join_str,
+                "loader_key":"steamship",
             }
 
             for tag in file.tags:

--- a/openagent/knowledgebase/document_loaders/steamship/base.py
+++ b/openagent/knowledgebase/document_loaders/steamship/base.py
@@ -77,7 +77,7 @@ class SteamshipFileReader(BaseReader):
                 "query": query,
                 "collapse_blocks": collapse_blocks,
                 "join_str": join_str,
-                "loader_key":"steamship",
+                "loader_id":"steamship",
             }
 
             for tag in file.tags:

--- a/openagent/knowledgebase/document_loaders/string_iterable/base.py
+++ b/openagent/knowledgebase/document_loaders/string_iterable/base.py
@@ -27,6 +27,6 @@ class StringIterableReader(BaseReader):
         """Load the data."""
         results = []
         for text in texts:
-            results.append(DocumentNode(text=text))
+            results.append(DocumentNode(text=text),  extra_info={"loader_key":"string_iterable"})
 
         return results

--- a/openagent/knowledgebase/document_loaders/string_iterable/base.py
+++ b/openagent/knowledgebase/document_loaders/string_iterable/base.py
@@ -27,6 +27,6 @@ class StringIterableReader(BaseReader):
         """Load the data."""
         results = []
         for text in texts:
-            results.append(DocumentNode(text=text),  extra_info={"loader_key":"string_iterable"})
+            results.append(DocumentNode(text=text),  extra_info={"loader_id":"string_iterable"})
 
         return results

--- a/openagent/knowledgebase/document_loaders/trello/base.py
+++ b/openagent/knowledgebase/document_loaders/trello/base.py
@@ -42,6 +42,7 @@ class TrelloReader(BaseReader):
                     "url": card.url,
                     "due_date": card.due_date,
                     "labels": [label.name for label in card.labels],
+                    "loader_key":"trello"
                 },
             )
             documents.append(doc)

--- a/openagent/knowledgebase/document_loaders/trello/base.py
+++ b/openagent/knowledgebase/document_loaders/trello/base.py
@@ -42,7 +42,7 @@ class TrelloReader(BaseReader):
                     "url": card.url,
                     "due_date": card.due_date,
                     "labels": [label.name for label in card.labels],
-                    "loader_key":"trello"
+                    "loader_id":"trello"
                 },
             )
             documents.append(doc)

--- a/openagent/knowledgebase/document_loaders/twitter/base.py
+++ b/openagent/knowledgebase/document_loaders/twitter/base.py
@@ -50,6 +50,6 @@ class TwitterTweetReader(BaseReader):
             response = " "
             for tweet in tweets.data:
                 response = response + tweet.text + "\n"
-            metadata = {"username": username, "loader_key":"twitter"}
+            metadata = {"username": username, "loader_id":"twitter"}
             results.append(DocumentNode(text=response, extra_info=metadata))
         return results

--- a/openagent/knowledgebase/document_loaders/twitter/base.py
+++ b/openagent/knowledgebase/document_loaders/twitter/base.py
@@ -50,6 +50,6 @@ class TwitterTweetReader(BaseReader):
             response = " "
             for tweet in tweets.data:
                 response = response + tweet.text + "\n"
-            metadata = {"username": username}
+            metadata = {"username": username, "loader_key":"twitter"}
             results.append(DocumentNode(text=response, extra_info=metadata))
         return results

--- a/openagent/knowledgebase/document_loaders/weather/base.py
+++ b/openagent/knowledgebase/document_loaders/weather/base.py
@@ -87,6 +87,6 @@ class WeatherReader(BaseReader):
                     i.to_dict() for i in res.national_weather_alerts
                 ]
 
-            results.append(DocumentNode(text=str(info_dict), extra_info=metadata))
+            results.append(DocumentNode(text=str(info_dict), extra_info={**metadata, "loader_key":"weather"}))
 
         return results

--- a/openagent/knowledgebase/document_loaders/weather/base.py
+++ b/openagent/knowledgebase/document_loaders/weather/base.py
@@ -87,6 +87,6 @@ class WeatherReader(BaseReader):
                     i.to_dict() for i in res.national_weather_alerts
                 ]
 
-            results.append(DocumentNode(text=str(info_dict), extra_info={**metadata, "loader_key":"weather"}))
+            results.append(DocumentNode(text=str(info_dict), extra_info={**metadata, "loader_id":"weather"}))
 
         return results

--- a/openagent/knowledgebase/document_loaders/weaviate/base.py
+++ b/openagent/knowledgebase/document_loaders/weaviate/base.py
@@ -59,7 +59,7 @@ class WeaviateReader(BaseReader):
             "class_name": class_name,
             "properties": properties,
             "graphql_query": graphql_query,
-            "loader_key":"weaviate",
+            "loader_id":"weaviate",
         }
 
         if class_name is not None and properties is not None:

--- a/openagent/knowledgebase/document_loaders/weaviate/base.py
+++ b/openagent/knowledgebase/document_loaders/weaviate/base.py
@@ -58,7 +58,8 @@ class WeaviateReader(BaseReader):
             "host": self.host,
             "class_name": class_name,
             "properties": properties,
-            "graphql_query": graphql_query
+            "graphql_query": graphql_query,
+            "loader_key":"weaviate",
         }
 
         if class_name is not None and properties is not None:

--- a/openagent/knowledgebase/document_loaders/web/async_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/async_web/base.py
@@ -100,6 +100,6 @@ class AsyncWebPageReader(BaseReader):
             else:
                 response_text = raw_page
 
-            documents.append(DocumentNode(text=response_text, extra_info={"Source": str(response.url), "loader_key":"async_web"}))
+            documents.append(DocumentNode(text=response_text, extra_info={"Source": str(response.url), "loader_id":"async_web"}))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/async_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/async_web/base.py
@@ -100,6 +100,6 @@ class AsyncWebPageReader(BaseReader):
             else:
                 response_text = raw_page
 
-            documents.append(DocumentNode(text=response_text, extra_info={"Source": str(response.url)}))
+            documents.append(DocumentNode(text=response_text, extra_info={"Source": str(response.url), "loader_key":"async_web"}))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/beautiful_soup_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/beautiful_soup_web/base.py
@@ -16,7 +16,7 @@ def _substack_reader(soup: Any, **kwargs) -> Tuple[str, Dict[str, Any]]:
         "Title of this Substack post": soup.select_one("h1.post-title").getText(),
         "Subtitle": soup.select_one("h3.subtitle").getText(),
         "Author": soup.select_one("span.byline-names").getText(),
-        "loader_key":"beautiful_soup_web",
+        "loader_id":"beautiful_soup_web",
     }
     text = soup.select_one("div.available-content").getText()
     return text, extra_info

--- a/openagent/knowledgebase/document_loaders/web/beautiful_soup_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/beautiful_soup_web/base.py
@@ -16,6 +16,7 @@ def _substack_reader(soup: Any, **kwargs) -> Tuple[str, Dict[str, Any]]:
         "Title of this Substack post": soup.select_one("h1.post-title").getText(),
         "Subtitle": soup.select_one("h3.subtitle").getText(),
         "Author": soup.select_one("span.byline-names").getText(),
+        "loader_key":"beautiful_soup_web",
     }
     text = soup.select_one("div.available-content").getText()
     return text, extra_info
@@ -185,7 +186,7 @@ class BeautifulSoupWebReader(BaseReader):
             soup = BeautifulSoup(page.content, "html.parser")
 
             data = ""
-            extra_info = {"URL": url}
+            extra_info = {"URL": url, "loader_key":"beautiful_soup_web"}
             if hostname in self.website_extractor:
                 data, metadata = self.website_extractor[hostname](
                     soup=soup, url=url, include_url_in_text=include_url_in_text

--- a/openagent/knowledgebase/document_loaders/web/knowledge_base/base.py
+++ b/openagent/knowledgebase/document_loaders/web/knowledge_base/base.py
@@ -72,7 +72,7 @@ class KnowledgeBaseWebReader(BaseReader):
                     "url": article["url"],
                     "root_url": self.root_url,
                     "article_path": self.article_path,
-                    "loader_key": "knowledge_base_web",
+                    "loader_id": "knowledge_base_web",
                 }
 
                 documents.append(DocumentNode(text=article["body"], extra_info=metadata))

--- a/openagent/knowledgebase/document_loaders/web/knowledge_base/base.py
+++ b/openagent/knowledgebase/document_loaders/web/knowledge_base/base.py
@@ -71,7 +71,8 @@ class KnowledgeBaseWebReader(BaseReader):
                     "subtitle": article["subtitle"],
                     "url": article["url"],
                     "root_url": self.root_url,
-                    "article_path": self.article_path
+                    "article_path": self.article_path,
+                    "loader_key": "knowledge_base_web",
                 }
 
                 documents.append(DocumentNode(text=article["body"], extra_info=metadata))

--- a/openagent/knowledgebase/document_loaders/web/readability_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/readability_web/base.py
@@ -107,7 +107,7 @@ class ReadabilityWebPageReader(BaseReader):
 
             browser.close()
 
-            return [DocumentNode(text=x, extra_info=metadata) for x in texts]
+            return [DocumentNode(text=x, extra_info={**metadata, "loader_key":"readability_web"}) for x in texts]
 
     def scrape_page(
         self,

--- a/openagent/knowledgebase/document_loaders/web/readability_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/readability_web/base.py
@@ -107,7 +107,7 @@ class ReadabilityWebPageReader(BaseReader):
 
             browser.close()
 
-            return [DocumentNode(text=x, extra_info={**metadata, "loader_key":"readability_web"}) for x in texts]
+            return [DocumentNode(text=x, extra_info={**metadata, "loader_id":"readability_web"}) for x in texts]
 
     def scrape_page(
         self,

--- a/openagent/knowledgebase/document_loaders/web/rss/base.py
+++ b/openagent/knowledgebase/document_loaders/web/rss/base.py
@@ -67,7 +67,7 @@ class RssReader(BaseReader):
 
                     data = html2text.html2text(data)
 
-                metadata = {"title": entry.title, "link": entry.link, "loader_key": "rss"}
+                metadata = {"title": entry.title, "link": entry.link, "loader_id": "rss"}
                 documents.append(DocumentNode(text=data, extra_info=metadata))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/rss/base.py
+++ b/openagent/knowledgebase/document_loaders/web/rss/base.py
@@ -67,7 +67,7 @@ class RssReader(BaseReader):
 
                     data = html2text.html2text(data)
 
-                metadata = {"title": entry.title, "link": entry.link}
+                metadata = {"title": entry.title, "link": entry.link, "loader_key": "rss"}
                 documents.append(DocumentNode(text=data, extra_info=metadata))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/simple_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/simple_web/base.py
@@ -41,7 +41,7 @@ class SimpleWebPageReader(BaseReader):
                 import html2text
 
                 response = html2text.html2text(response)
-            metadata = {"url": url}
+            metadata = {"url": url, "loader_key":"simple_web"}
             documents.append(DocumentNode(text=response, extra_info=metadata))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/simple_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/simple_web/base.py
@@ -41,7 +41,7 @@ class SimpleWebPageReader(BaseReader):
                 import html2text
 
                 response = html2text.html2text(response)
-            metadata = {"url": url, "loader_key":"simple_web"}
+            metadata = {"url": url, "loader_id":"simple_web"}
             documents.append(DocumentNode(text=response, extra_info=metadata))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/trafilatura_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/trafilatura_web/base.py
@@ -30,7 +30,7 @@ class TrafilaturaWebReader(BaseReader):
         for url in urls:
             downloaded = trafilatura.fetch_url(url)
             response = trafilatura.extract(downloaded)
-            metadata = {"url": url}
+            metadata = {"url": url, "loader_key":"trafilatura_web"}
             documents.append(DocumentNode(text=response, extra_info=metadata))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/trafilatura_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/trafilatura_web/base.py
@@ -30,7 +30,7 @@ class TrafilaturaWebReader(BaseReader):
         for url in urls:
             downloaded = trafilatura.fetch_url(url)
             response = trafilatura.extract(downloaded)
-            metadata = {"url": url, "loader_key":"trafilatura_web"}
+            metadata = {"url": url, "loader_id":"trafilatura_web"}
             documents.append(DocumentNode(text=response, extra_info=metadata))
 
         return documents

--- a/openagent/knowledgebase/document_loaders/web/unstructured_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/unstructured_web/base.py
@@ -53,7 +53,7 @@ class UnstructuredURLLoader(BaseLoader):
                 else:
                     elements = partition_html(url=url)
                 text = "\n\n".join([str(el) for el in elements])
-                metadata = {"source": url}
+                metadata = {"source": url, "loader_key": "unstructured_web"}
                 docs.append(DocumentNode(text=text, extra_info=metadata))
             except Exception as e:
                 if self.continue_on_failure:

--- a/openagent/knowledgebase/document_loaders/web/unstructured_web/base.py
+++ b/openagent/knowledgebase/document_loaders/web/unstructured_web/base.py
@@ -53,7 +53,7 @@ class UnstructuredURLLoader(BaseLoader):
                 else:
                     elements = partition_html(url=url)
                 text = "\n\n".join([str(el) for el in elements])
-                metadata = {"source": url, "loader_key": "unstructured_web"}
+                metadata = {"source": url, "loader_id": "unstructured_web"}
                 docs.append(DocumentNode(text=text, extra_info=metadata))
             except Exception as e:
                 if self.continue_on_failure:

--- a/openagent/knowledgebase/document_loaders/whatsapp/base.py
+++ b/openagent/knowledgebase/document_loaders/whatsapp/base.py
@@ -43,7 +43,7 @@ class WhatsappChatLoader(BaseReader):
                 "source": str(path).split("/")[-1].replace(".txt", ""),
                 "author": row.author,
                 "timestamp": str(row.timestamp),
-                "loader_key":"whatsapp",
+                "loader_id":"whatsapp",
             }
 
             docs.append(

--- a/openagent/knowledgebase/document_loaders/whatsapp/base.py
+++ b/openagent/knowledgebase/document_loaders/whatsapp/base.py
@@ -43,6 +43,7 @@ class WhatsappChatLoader(BaseReader):
                 "source": str(path).split("/")[-1].replace(".txt", ""),
                 "author": row.author,
                 "timestamp": str(row.timestamp),
+                "loader_key":"whatsapp",
             }
 
             docs.append(

--- a/openagent/knowledgebase/document_loaders/wikipedia/base.py
+++ b/openagent/knowledgebase/document_loaders/wikipedia/base.py
@@ -27,5 +27,5 @@ class WikipediaReader(BaseReader):
         for page in pages:
             wikipedia.set_lang(lang)
             page_content = wikipedia.page(page, **load_kwargs).content
-            results.append(DocumentNode(text=page_content, extra_info={"page": page, "language": lang}))
+            results.append(DocumentNode(text=page_content, extra_info={"page": page, "language": lang, "loader_key":"wikipedia"}))
         return results

--- a/openagent/knowledgebase/document_loaders/wikipedia/base.py
+++ b/openagent/knowledgebase/document_loaders/wikipedia/base.py
@@ -27,5 +27,5 @@ class WikipediaReader(BaseReader):
         for page in pages:
             wikipedia.set_lang(lang)
             page_content = wikipedia.page(page, **load_kwargs).content
-            results.append(DocumentNode(text=page_content, extra_info={"page": page, "language": lang, "loader_key":"wikipedia"}))
+            results.append(DocumentNode(text=page_content, extra_info={"page": page, "language": lang, "loader_id":"wikipedia"}))
         return results

--- a/openagent/knowledgebase/document_loaders/wordlift/base.py
+++ b/openagent/knowledgebase/document_loaders/wordlift/base.py
@@ -137,7 +137,8 @@ class WordLiftLoader(BaseReader):
                 
                 metadata["endpoint"] = self.endpoint
                 metadata["query"] = self.query
-                DocumentNode = DocumentNode(text=text, extra_info=metadata)
+                
+                DocumentNode = DocumentNode(text=text, extra_info={**metadata, "loader_key":"wordlift"})
                 documents.append(DocumentNode)
 
             return documents

--- a/openagent/knowledgebase/document_loaders/wordlift/base.py
+++ b/openagent/knowledgebase/document_loaders/wordlift/base.py
@@ -138,7 +138,7 @@ class WordLiftLoader(BaseReader):
                 metadata["endpoint"] = self.endpoint
                 metadata["query"] = self.query
                 
-                DocumentNode = DocumentNode(text=text, extra_info={**metadata, "loader_key":"wordlift"})
+                DocumentNode = DocumentNode(text=text, extra_info={**metadata, "loader_id":"wordlift"})
                 documents.append(DocumentNode)
 
             return documents

--- a/openagent/knowledgebase/document_loaders/wordpress/base.py
+++ b/openagent/knowledgebase/document_loaders/wordpress/base.py
@@ -47,6 +47,7 @@ class WordpressReader(BaseReader):
                 "title": title,
                 "url": article["link"],
                 "updated_at": article["modified"],
+                "loader_key":"wordpress",
             }
 
             results.append(

--- a/openagent/knowledgebase/document_loaders/wordpress/base.py
+++ b/openagent/knowledgebase/document_loaders/wordpress/base.py
@@ -47,7 +47,7 @@ class WordpressReader(BaseReader):
                 "title": title,
                 "url": article["link"],
                 "updated_at": article["modified"],
-                "loader_key":"wordpress",
+                "loader_id":"wordpress",
             }
 
             results.append(

--- a/openagent/knowledgebase/document_loaders/youtube_transcript/base.py
+++ b/openagent/knowledgebase/document_loaders/youtube_transcript/base.py
@@ -48,5 +48,5 @@ class YoutubeTranscriptReader(BaseReader):
             transcript = ""
             for chunk in srt:
                 transcript = transcript + chunk["text"] + "\n"
-            results.append(DocumentNode(text=transcript, extra_info={"video_id": video_id, "video_link": link}))
+            results.append(DocumentNode(text=transcript, extra_info={"video_id": video_id, "video_link": link, "loader_key":"youtube_transcript"}))
         return results

--- a/openagent/knowledgebase/document_loaders/youtube_transcript/base.py
+++ b/openagent/knowledgebase/document_loaders/youtube_transcript/base.py
@@ -48,5 +48,5 @@ class YoutubeTranscriptReader(BaseReader):
             transcript = ""
             for chunk in srt:
                 transcript = transcript + chunk["text"] + "\n"
-            results.append(DocumentNode(text=transcript, extra_info={"video_id": video_id, "video_link": link, "loader_key":"youtube_transcript"}))
+            results.append(DocumentNode(text=transcript, extra_info={"video_id": video_id, "video_link": link, "loader_id":"youtube_transcript"}))
         return results

--- a/openagent/knowledgebase/document_loaders/zendesk/base.py
+++ b/openagent/knowledgebase/document_loaders/zendesk/base.py
@@ -45,7 +45,7 @@ class ZendeskReader(BaseReader):
                 "updated_at": article["updated_at"],
                 "zendesk_subdomain": self.zendesk_subdomain,
                 "locale": self.locale,
-                "loader_key":"zendesk",
+                "loader_id":"zendesk",
             }
 
             results.append(

--- a/openagent/knowledgebase/document_loaders/zendesk/base.py
+++ b/openagent/knowledgebase/document_loaders/zendesk/base.py
@@ -44,7 +44,8 @@ class ZendeskReader(BaseReader):
                 "url": article["html_url"],
                 "updated_at": article["updated_at"],
                 "zendesk_subdomain": self.zendesk_subdomain,
-                "locale": self.locale
+                "locale": self.locale,
+                "loader_key":"zendesk",
             }
 
             results.append(

--- a/openagent/knowledgebase/document_loaders/zulip/base.py
+++ b/openagent/knowledgebase/document_loaders/zulip/base.py
@@ -55,8 +55,8 @@ class ZulipReader(BaseReader):
         for stream_name in streams:
             stream_content = self._read_stream(stream_name, reverse_chronological)
             data.append(
-                DocumentNode(text=stream_content, extra_info={"stream": stream_name})
-            )
+                DocumentNode(text=stream_content, extra_info={"stream": stream_name, "loader_key":"zulip"})
+            )   
         return data
 
     def get_all_streams(self) -> list:

--- a/openagent/knowledgebase/document_loaders/zulip/base.py
+++ b/openagent/knowledgebase/document_loaders/zulip/base.py
@@ -55,7 +55,7 @@ class ZulipReader(BaseReader):
         for stream_name in streams:
             stream_content = self._read_stream(stream_name, reverse_chronological)
             data.append(
-                DocumentNode(text=stream_content, extra_info={"stream": stream_name, "loader_key":"zulip"})
+                DocumentNode(text=stream_content, extra_info={"stream": stream_name, "loader_id":"zulip"})
             )   
         return data
 


### PR DESCRIPTION
"We decided to change the key to 'id' to avoid any potential confusion. When we mention 'loader_key,' it might be associated with an API key, while 'id' specifically refers to the loader used for retrieving  the document. This change in naming provides clarity and helps distinguish between different types of keys."